### PR TITLE
Raspi fixes

### DIFF
--- a/projects/BUILD_HOW_TO.txt
+++ b/projects/BUILD_HOW_TO.txt
@@ -9,3 +9,8 @@ GP2X: Compile under minsys
 PSP: Compile under minsys
 
 DINGOO: Compile under Linux
+
+RASPI: Compile under Linux
+	Required libs:
+	    sudo apt install -y git gcc libsdl1.2-dev make g++ libjack-dev
+

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -24,7 +24,7 @@ bool SampleInstrument::useDirtyDownsampling_ = false;
 
 #define SHOULD_KILL_CLICKS false
 
-char SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT]= {
+signed char SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT]= {
 	-1,-1,-1,-1,-1,-1,-1,-1
 } ;
 

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -24,7 +24,7 @@ bool SampleInstrument::useDirtyDownsampling_ = false;
 
 #define SHOULD_KILL_CLICKS false
 
-signed char SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT]= {
+int8_t SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT]= {
 	-1,-1,-1,-1,-1,-1,-1,-1
 } ;
 

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -100,7 +100,7 @@ private:
        bool dirty_ ;
 	   TableSaveState tableState_ ;
 
-	   static char lastMidiNote_[SONG_CHANNEL_COUNT] ;
+	   static signed char lastMidiNote_[SONG_CHANNEL_COUNT] ;
 	   static fixed lastSample_[SONG_CHANNEL_COUNT][2] ;
 	   static fixed feedback_[SONG_CHANNEL_COUNT][FB_BUFFER_LENGTH*2] ;
 

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -99,8 +99,8 @@ private:
        bool running_ ;
        bool dirty_ ;
 	   TableSaveState tableState_ ;
-
-	   static signed char lastMidiNote_[SONG_CHANNEL_COUNT] ;
+	   
+	   static int8_t lastMidiNote_[SONG_CHANNEL_COUNT] ;
 	   static fixed lastSample_[SONG_CHANNEL_COUNT][2] ;
 	   static fixed feedback_[SONG_CHANNEL_COUNT][FB_BUFFER_LENGTH*2] ;
 

--- a/sources/Externals/Soundfont/SFREADER.H
+++ b/sources/Externals/Soundfont/SFREADER.H
@@ -94,7 +94,7 @@ class sfReader {
   #ifdef USE_MACINTOSH
   HydraClass*  ReadSFBFile(FSSpec * pSpecifier, CHAR *chReqdWaveTable = '\0');
   #endif
-  HydraClass*  ReadSFBFile(CHAR *sfFileName, CHAR *chReqdWaveTable = '\0');
+  HydraClass*  ReadSFBFile(CHAR *sfFileName, CHAR *chReqdWaveTable = NULL);
  
   BOOL         IsValid(void);
 


### PR DESCRIPTION
Replace signed char with uint8_t 
NULL initialization of ReadSFBFile char pointer
Add build dependencies in README

This patch fixes DEB/RASPI build errors.
