### PR TITLE
Replace assertion error with log print

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -881,8 +881,9 @@ void Player::playCursorPosition(int channel) {
 							tpb.Stop() ;
 						}
 					}
-				} else {
-					NAssert(0) ;
+				} 
+				else {
+					Trace::Error("Note outside range: %02x", (unsigned int) note) ;
 				}
 			}
 		}


### PR DESCRIPTION
Transposing using phrase transposition might cause the application to crash Replace the assertion on line 886 with a log print to avoid crashes