### PR TITLE
End preview

### DIFF
--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -119,6 +119,10 @@ void ImportSampleDialog::preview(Path &element) {
 	Player::GetInstance()->StartStreaming(element) ;
 }
 
+void ImportSampleDialog::endPreview() {
+	Player::GetInstance()->StopStreaming() ;
+}
+
 void ImportSampleDialog::import(Path &element) {
 
 	SamplePool *pool=SamplePool::GetInstance() ;
@@ -138,7 +142,7 @@ void ImportSampleDialog::import(Path &element) {
 
 void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
-	if (!pressed) return ;
+	if (!pressed){ endPreview(); return; } //Not continue to playing when browsing etc.
 
 	if (mask&EPBM_B) {  
 		if (mask&EPBM_UP) warpToNextSample(-LIST_SIZE) ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -142,7 +142,7 @@ void ImportSampleDialog::import(Path &element) {
 
 void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
-	if (!pressed){ endPreview(); return; } //Not continue to playing when browsing etc.
+	if (!pressed){ endPreview(); return; } //Don't continue to play when browsing etc
 
 	if (mask&EPBM_B) {  
 		if (mask&EPBM_UP) warpToNextSample(-LIST_SIZE) ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -142,7 +142,7 @@ void ImportSampleDialog::import(Path &element) {
 
 void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
-	if (!pressed){ endPreview(); return; } //Don't continue to play when browsing etc
+	if (!pressed) return ;
 
 	if (mask&EPBM_B) {  
 		if (mask&EPBM_UP) warpToNextSample(-LIST_SIZE) ;
@@ -152,7 +152,7 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 	  // A modifier
 	  if (mask&EPBM_A) { 
 
-		// Allow preview while browsing
+		// Allow browse preview
 		if (mask&EPBM_UP) warpToNextSample(-1) ;
 		if (mask&EPBM_DOWN) warpToNextSample(1) ;
 
@@ -187,9 +187,10 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				if(!element->IsDirectory()) preview(*element) ; // Don't browse preview folders
 				break ;
 			case 1: // import
-				import(*element) ;
+				if(!element->IsDirectory()) import(*element) ; // Don't browse import folders
 				break ;
 			case 2: // Exit ;
+				endPreview(); // Stop playback when exiting
 				EndModal(0) ;
 				break ;
 		}

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -184,7 +184,7 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
 		switch(selected_) {
 			case 0: // preview
-			if(!element->IsDirectory()) preview(*element) ; // Don't browse preview folders
+				if(!element->IsDirectory()) preview(*element) ; // Don't browse preview folders
 				break ;
 			case 1: // import
 				import(*element) ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -151,6 +151,11 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
 	  // A modifier
 	  if (mask&EPBM_A) { 
+
+		// Allow preview while browsing
+		if (mask&EPBM_UP) warpToNextSample(-1) ;
+		if (mask&EPBM_DOWN) warpToNextSample(1) ;
+
 		IteratorPtr<Path> it(sampleList_.GetIterator()) ;
 		int count=0 ;
 		Path *element=0 ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -165,7 +165,8 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 			}
 		}
 
-		if ((selected_!=2)&&(element->IsDirectory())) {
+		if ((selected_!=2)&&(element->IsDirectory()) && // Folders
+			!(mask&EPBM_UP||mask&EPBM_DOWN)) { // Don't browse preview folders
 			if (element->GetName()=="..") {
 				if (currentPath_.GetPath()==sampleLib_.GetPath()) {
 	//				EndModal(true) ;
@@ -183,7 +184,7 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
 		switch(selected_) {
 			case 0: // preview
-				preview(*element) ;
+			if(!element->IsDirectory()) preview(*element) ; // Don't browse preview folders
 				break ;
 			case 1: // import
 				import(*element) ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
@@ -21,6 +21,7 @@ protected:
 	void warpToNextSample(int dir) ;
 	void import(Path &element) ;
 	void preview(Path &element) ;
+	void endPreview() ;
 private:
 	T_SimpleList<Path> sampleList_ ;
 	int currentSample_ ;


### PR DESCRIPTION
Piggy is notorious for not stopping playback of long samples.
This patch only plays a sample as long as the preview button is pressed down,

@INFU-AV is this reasonable behavior to you?