### PR TITLE
Improve sample browser

### DIFF
--- a/docs/wiki/What-is-LittleGPTracker.md
+++ b/docs/wiki/What-is-LittleGPTracker.md
@@ -330,9 +330,11 @@ In oscillator modes, under 0x80 the feedback of specified length is added to the
 - **interpolation:** Interpolation mode ('linear'/'none'): selects which interpolation mode is used when in between samples. linear interpols linearly while none takes the nearest neighbor. Use none when playing samples at low range to add some typical overtones.
 - **loop mode:** selects the looping mode.
   - none will play sample from zero to end.
-  - loop will start at zero and loop from loopstart to end.
+  - loop will start at zero and loop from loop start to loop end.
+  - pingpong will start at "start" and bounce the loop between loop start and loop end.
+  - oscillator is a special mode where the loop selection (from loop start to loop end) is taken as oscillator data and automatically tuned. Experiment with different settings, do not forget 'root note' is your friend to tune the oscillator back in a useful range
   - looper sync will automatically tune a loop so that it plays exactly 16 bars. Use the root note to play twice faster/slower
-  - oscillator is a special mode where the loop selection (from loopstart to end) is taken as oscillator data and automatically tuned. Experiment with different settings, do not forget 'root note' is your friend to tune the oscillator back in a useful range
+  - slicer will cut the sample into "slices" amount of samples, mapped from C-2 up to amount of slices
 - **start:** start point of the sample regardless of if loop is enabled; in hex
 - **loop Start:** start point of the sample when loop is enabled; in hex
 - **loop End:** end point of the sample; in hex. You can play samples backwards by setting the end value lower than the start!
@@ -348,11 +350,11 @@ The samples of the library have to be located in a folder samplelib at the same 
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_B9C92C3440E8671360862F10CAB0FE70873BFE49CFB51CA246C781C17506C258_1522140496106_sample_import_1.1f.png)
 
 
-When entering the import screen, the current folder is the library root folder “samplelib”. All sample in that folder are listed.
-Use U/D to select a sample and 'A' to load it
-B+L/R to rotates between all sub directories.
-In the latest ghetto, hitting 'A,A“ will bring up a sample loader pop-up screen, use the cursor to select directories and samples, and chose “listen” to play the sample, “import” to add it to your project, or “exit” to return the instrument screen.
-For quick sample navigation, hold Start to preview. Keep holding start and navigate up/down to preview samples while navigating. Hold Start and Press Left to navigate up in the folder structure. Hold Start and press Right to load a sample.
+Hitting "A,A“ on the sample selection of the instrument screen will bring up a sample import pop-up screen. Use the cursor to select directories and samples. 
+When entering the import screen, the current folder is the library root folder “samplelib”. All samples and folders in that folder are listed.
+B+L/R jumps a page up/down in the sample folder.
+Legacy: Using A, choose “listen” to play the sample, “import” to add it to your project, or “exit” to return the instrument screen. Hold A and navigate up/down to preview samples while navigating.
+New in beta-2: Hold Start to preview. Keep holding start and navigate up/down to preview samples while navigating. Hold Start and Press Left to navigate up in the folder structure. Hold Start and press Right to load a sample.
 
 ## Midi Instrument Screen
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_B9C92C3440E8671360862F10CAB0FE70873BFE49CFB51CA246C781C17506C258_1522140537386_midi_1.1f.png)

--- a/docs/wiki/What-is-LittleGPTracker.md
+++ b/docs/wiki/What-is-LittleGPTracker.md
@@ -352,6 +352,7 @@ When entering the import screen, the current folder is the library root folder �
 Use U/D to select a sample and 'A' to load it
 B+L/R to rotates between all sub directories.
 In the latest ghetto, hitting 'A,A“ will bring up a sample loader pop-up screen, use the cursor to select directories and samples, and chose “listen” to play the sample, “import” to add it to your project, or “exit” to return the instrument screen.
+For quick sample navigation, hold Start to preview. Keep holding start and navigate up/down to preview samples while navigating. Hold Start and Press Left to navigate up in the folder structure. Hold Start and press Right to load a sample.
 
 ## Midi Instrument Screen
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_B9C92C3440E8671360862F10CAB0FE70873BFE49CFB51CA246C781C17506C258_1522140537386_midi_1.1f.png)

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -17,7 +17,7 @@
 
 #define PROJECT_NUMBER "1.3"
 #define PROJECT_RELEASE "o"
-#define BUILD_COUNT "beta-1"
+#define BUILD_COUNT "beta-2"
 
 #define MAX_TAP 3
 

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -152,7 +152,6 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 
 	  // A modifier
 	  if (mask&EPBM_A) { 
-
 		// Allow browse preview
 		if (mask&EPBM_UP) warpToNextSample(-1) ;
 		if (mask&EPBM_DOWN) warpToNextSample(1) ;
@@ -176,10 +175,7 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				EndModal(0) ;
 				break ;
 		}
-	  } else {
-		// START Modifier
-		if (mask&EPBM_START) {
-			if (mask&(EPBM_L)) { return; } //No action
+	  } else if (mask&EPBM_START) { // START Modifier
 			if (mask&EPBM_UP) warpToNextSample(-1);
 			if (mask&EPBM_DOWN) warpToNextSample(1);
 			Path *element = getImportElement();
@@ -200,8 +196,7 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 					isDirty_=true;
 				}
 			}
-		} else {
-			// No modifier
+	  } else { // No modifier
 			if (mask==EPBM_UP) warpToNextSample(-1) ;
 			if (mask==EPBM_DOWN) warpToNextSample(1) ;
 			if (mask==EPBM_LEFT) {
@@ -214,7 +209,6 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				isDirty_=true ;
 			}
 		}
-	  } 
 	}
 } ;
 

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -197,25 +197,25 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				}
 			}
 	  } else { // No modifier
-			if (mask==EPBM_UP) warpToNextSample(-1) ;
-			if (mask==EPBM_DOWN) warpToNextSample(1) ;
+			if (mask==EPBM_UP) warpToNextSample(-1);
+			if (mask==EPBM_DOWN) warpToNextSample(1);
 			if (mask==EPBM_LEFT) {
-				selected_-=1 ;
-				if (selected_<0) selected_+=3 ;
-				isDirty_=true ;
+				selected_-=1;
+				if (selected_<0) selected_+=3;
+				isDirty_=true;
 			}
 			if (mask==EPBM_RIGHT) {
-				selected_=(selected_+1)%3 ;
-				isDirty_=true ;
+				selected_=(selected_+1)%3;
+				isDirty_=true;
 			}
 		}
 	}
 } ;
 
 Path* ImportSampleDialog::getImportElement() {
-	IteratorPtr<Path> it(sampleList_.GetIterator()) ;
-	int count = 0 ;
-	Path *element = 0 ;
+	IteratorPtr<Path> it(sampleList_.GetIterator());
+	int count = 0;
+	Path *element = 0;
 	for(it->Begin(); !it->IsDone(); it->Next()) {
 		if (count++ == currentSample_) {
 			return &it->CurrentItem();
@@ -233,9 +233,9 @@ void ImportSampleDialog::setCurrent(Path *element, unsigned short mask) {
 				setCurrentFolder(&parent);
 			}
 		} else {
-			setCurrentFolder(element) ;
+			setCurrentFolder(element);
 		}
-		isDirty_=true;
+		isDirty_ = true;
 		return;
 	}
 }

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -179,18 +179,25 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 	  } else {
 		// START Modifier
 		if (mask&EPBM_START) {
-			if (mask&(EPBM_RIGHT|EPBM_LEFT|EPBM_L)) { return; } //No action
+			if (mask&(EPBM_L)) { return; } //No action
 			if (mask&EPBM_UP) warpToNextSample(-1);
 			if (mask&EPBM_DOWN) warpToNextSample(1);
 			Path *element = getImportElement();
 			setCurrent(element, mask);
-			if(!element->IsDirectory()) { // Don't browse preview folders
+			if(!element->IsDirectory()) {
 				preview(*element); 
 			}
-			if (mask&EPBM_R) { 
-				if (!element->IsDirectory()) { // Don't browse import folders
+			if (mask&EPBM_RIGHT) { // Load sample
+				if (!element->IsDirectory()) {
 					endPreview();
 					import(*element);
+				}
+			}
+			if (mask&EPBM_LEFT) { // Navigate up
+				if (currentPath_.GetPath()!=sampleLib_.GetPath()) {
+					Path parent = element->GetParent().GetParent();
+					setCurrentFolder(&parent);
+					isDirty_=true;
 				}
 			}
 		} else {
@@ -223,10 +230,7 @@ Path* ImportSampleDialog::getImportElement() {
 }
 
 void ImportSampleDialog::setCurrent(Path *element, unsigned short mask) {
-	if (
-		(selected_ != 2) && (element->IsDirectory())  // Folders
-		//&& !(mask&EPBM_UP || mask&EPBM_DOWN) // Don't browse preview folders
-	   )
+	if (selected_ != 2 && element->IsDirectory())
 	{
 		if (element->GetName()=="..") {
 			if (currentPath_.GetPath()==sampleLib_.GetPath()) {

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -101,8 +101,9 @@ void ImportSampleDialog::warpToNextSample(int direction) {
 
 	currentSample_+=direction ;
 	int size=sampleList_.Size() ;
-	if (currentSample_<0) currentSample_+=size ;
-	if (currentSample_>=size) currentSample_-=size ;
+	if (currentSample_ < 0) currentSample_ = 0;
+	if (currentSample_ >= size) currentSample_ = size - 1;
+	endPreview();
 	isDirty_=true ;
 }
 
@@ -156,38 +157,19 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 		if (mask&EPBM_UP) warpToNextSample(-1) ;
 		if (mask&EPBM_DOWN) warpToNextSample(1) ;
 
-		IteratorPtr<Path> it(sampleList_.GetIterator()) ;
-		int count=0 ;
-		Path *element=0 ;
-		for(it->Begin();!it->IsDone();it->Next()) {
-			if (count++==currentSample_) {
-				element=&it->CurrentItem() ;
-			}
-		}
-
-		if ((selected_!=2)&&(element->IsDirectory()) && // Folders
-			!(mask&EPBM_UP||mask&EPBM_DOWN)) { // Don't browse preview folders
-			if (element->GetName()=="..") {
-				if (currentPath_.GetPath()==sampleLib_.GetPath()) {
-	//				EndModal(true) ;
-				} else {;
-					Path parent=element->GetParent().GetParent() ;
-					setCurrentFolder(&parent) ;
-				}
-			} else {
-				setCurrentFolder(element) ;
-			}
-			isDirty_=true ;
-			return ;
-		}
-
+		Path *element = getImportElement();
+		setCurrent(element, mask);
 
 		switch(selected_) {
 			case 0: // preview
-				if(!element->IsDirectory()) preview(*element) ; // Don't browse preview folders
+				if(!element->IsDirectory()) { // Don't browse preview folders
+					preview(*element);
+				}
 				break ;
 			case 1: // import
-				if(!element->IsDirectory()) import(*element) ; // Don't browse import folders
+				if(!element->IsDirectory()) { // Don't browse import folders
+					import(*element);
+				}
 				break ;
 			case 2: // Exit ;
 				endPreview(); // Stop playback when exiting
@@ -195,27 +177,70 @@ void ImportSampleDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				break ;
 		}
 	  } else {
-
-		  // R Modifier
-
-          	if (mask&EPBM_R) {
-	    	} else {
-                // No modifier
-				if (mask==EPBM_UP) warpToNextSample(-1) ;
-				if (mask==EPBM_DOWN) warpToNextSample(1) ;
-				if (mask==EPBM_LEFT) {
-					selected_-=1 ;
-					if (selected_<0) selected_+=3 ;
-					isDirty_=true ;
+		// START Modifier
+		if (mask&EPBM_START) {
+			if (mask&(EPBM_RIGHT|EPBM_LEFT|EPBM_L)) { return; } //No action
+			if (mask&EPBM_UP) warpToNextSample(-1);
+			if (mask&EPBM_DOWN) warpToNextSample(1);
+			Path *element = getImportElement();
+			setCurrent(element, mask);
+			if(!element->IsDirectory()) { // Don't browse preview folders
+				preview(*element); 
+			}
+			if (mask&EPBM_R) { 
+				if (!element->IsDirectory()) { // Don't browse import folders
+					endPreview();
+					import(*element);
 				}
-				if (mask==EPBM_RIGHT) {
-					selected_=(selected_+1)%3 ;
-					isDirty_=true ;
-				}
-		    }
+			}
+		} else {
+			// No modifier
+			if (mask==EPBM_UP) warpToNextSample(-1) ;
+			if (mask==EPBM_DOWN) warpToNextSample(1) ;
+			if (mask==EPBM_LEFT) {
+				selected_-=1 ;
+				if (selected_<0) selected_+=3 ;
+				isDirty_=true ;
+			}
+			if (mask==EPBM_RIGHT) {
+				selected_=(selected_+1)%3 ;
+				isDirty_=true ;
+			}
+		}
 	  } 
 	}
 } ;
+
+Path* ImportSampleDialog::getImportElement() {
+	IteratorPtr<Path> it(sampleList_.GetIterator()) ;
+	int count = 0 ;
+	Path *element = 0 ;
+	for(it->Begin(); !it->IsDone(); it->Next()) {
+		if (count++ == currentSample_) {
+			return &it->CurrentItem();
+		}
+	}
+}
+
+void ImportSampleDialog::setCurrent(Path *element, unsigned short mask) {
+	if (
+		(selected_ != 2) && (element->IsDirectory())  // Folders
+		//&& !(mask&EPBM_UP || mask&EPBM_DOWN) // Don't browse preview folders
+	   )
+	{
+		if (element->GetName()=="..") {
+			if (currentPath_.GetPath()==sampleLib_.GetPath()) {
+			} else {
+				Path parent = element->GetParent().GetParent();
+				setCurrentFolder(&parent);
+			}
+		} else {
+			setCurrentFolder(element) ;
+		}
+		isDirty_=true;
+		return;
+	}
+}
 
 void ImportSampleDialog::setCurrentFolder(Path *path) {
 

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
@@ -17,14 +17,16 @@ public:
 	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
 
 protected:
-	void setCurrentFolder(Path *path) ;
-	void warpToNextSample(int dir) ;
+    void setCurrentFolder(Path *path);
+    void warpToNextSample(int dir) ;
 	void import(Path &element) ;
 	void preview(Path &element) ;
 	void endPreview() ;
 private:
-	T_SimpleList<Path> sampleList_ ;
-	int currentSample_ ;
+    Path *getImportElement();
+    void setCurrent(Path *element, unsigned short mask);
+    T_SimpleList<Path> sampleList_;
+    int currentSample_ ;
 	int topIndex_ ;
 	int toInstr_ ;
 	int selected_ ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
@@ -17,16 +17,16 @@ public:
 	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
 
 protected:
-    void setCurrentFolder(Path *path);
-    void warpToNextSample(int dir) ;
+	void setCurrentFolder(Path *path);
+	void warpToNextSample(int dir) ;
 	void import(Path &element) ;
 	void preview(Path &element) ;
 	void endPreview() ;
 private:
-    Path *getImportElement();
-    void setCurrent(Path *element, unsigned short mask);
-    T_SimpleList<Path> sampleList_;
-    int currentSample_ ;
+	Path *getImportElement();
+	void setCurrent(Path *element, unsigned short mask);
+	T_SimpleList<Path> sampleList_;
+	int currentSample_ ;
 	int topIndex_ ;
 	int toInstr_ ;
 	int selected_ ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.h
@@ -17,7 +17,7 @@ public:
 	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
 
 protected:
-	void setCurrentFolder(Path *path);
+	void setCurrentFolder(Path *path) ;
 	void warpToNextSample(int dir) ;
 	void import(Path &element) ;
 	void preview(Path &element) ;
@@ -25,7 +25,7 @@ protected:
 private:
 	Path *getImportElement();
 	void setCurrent(Path *element, unsigned short mask);
-	T_SimpleList<Path> sampleList_;
+	T_SimpleList<Path> sampleList_ ;
 	int currentSample_ ;
 	int topIndex_ ;
 	int toInstr_ ;


### PR DESCRIPTION
Use start to fast navigate samples
Hold start to preview, keep holding it and use the following modifiers:
Up / down: When on a sample - preview the sample. If folder or "..", navigate into folder
Left: Navigate up in folder structure (same as "..")
Right: Load sample to project

B + up / down jumps a page. Does not wrap, but stays at the top or bottom sample.