### PR TITLE
Play chain offset

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -143,7 +143,7 @@ void Player::Start(PlayMode mode,bool forceSongMode) {
       for (int i=0;i<8;i++)
       {
         mixer_->StartChannel(i) ;
-        updateSongPos(playPos,i) ;
+        updateSongPos(playPos, i, viewData_->chainRow_);
       }
     }
     break ;

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -93,19 +93,9 @@ void Player::Start(PlayMode mode,bool forceSongMode) {
  
 	viewData_->playMode_=(forceSongMode?PM_SONG:mode) ;
 
-  // See if we start from current song position
-  // or from last stored
-
+  // Always set position, allows for playing song with chain offset
   unsigned playPos=viewData_->songY_+viewData_->songOffset_ ;
-
-	if (forceSongMode==false)
-  {
-    lastSongPos_=playPos ;
-  } 
-  else 
-  {
-    playPos=lastSongPos_ ;
-  }
+  lastSongPos_ = playPos;
 
   // Clear all channel based data
 

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -733,6 +733,8 @@ void SongView::processNormalButtonMask(unsigned int mask) {
 	    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
 
 	          		if (mask&EPBM_START) {
+					   // Always play with zero offset in chains when in songview
+					   viewData_->chainRow_ = 0;
 					   onStart() ;
 	    			}
 				}


### PR DESCRIPTION
When in chain view, pressing R+Start plays the current song row
with the offset from current chain row.