### PR TITLE
Adds nudge functionality

### DIFF
--- a/docs/wiki/What-is-LittlePiggyTracker.md
+++ b/docs/wiki/What-is-LittlePiggyTracker.md
@@ -258,7 +258,7 @@ To move from one screen to the other, press the RTrigger combined with the direc
 
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_B9C92C3440E8671360862F10CAB0FE70873BFE49CFB51CA246C781C17506C258_1522140419022_project_1.1f.png)
 
-- **Tempo:**: Can be set between 60bpm [0x3c] and 400bpm [0x190]. Resolution aligned to LSDJ.
+- **Tempo:**: Can be set between 60bpm [0x3c] and 400bpm [0x190]. Resolution aligned to LSDJ. (nudge with b + left / right)
 - **Master:** Main volume goes from 10% to 200%. Piggy is loud now!
 - **Transpose:** Live transposition of every triggered instruments.
 - **Compact Sequencer:** Free all unused chain/phrases.
@@ -282,6 +282,7 @@ To move from one screen to the other, press the RTrigger combined with the direc
 - Make a big selection by pressing LT+B, then DPAD around to highlight.
 - Press LT+A to paste.
 - You can jump the cursor to the next/previous chain in a column by pressing LT+DOWN/UP
+- When playing live with multiple devices, you can nudge dragging/rushing devices by pressing LT+LEFT/RIGHT
 
 ## Chain Screen
 

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -73,7 +73,8 @@ int Project::GetMasterVolume() {
 } ;
 
 void Project::NudgeTempo(int value) {
-	tempoNudge_+=value ;
+	if((GetTempo() + tempoNudge_) > 0)
+		tempoNudge_ += value;
 } ;
 
 void Project::Trigger() {

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -4,6 +4,7 @@
 #include "Application/Utils/char.h"
 #include "Application/Player/Player.h"
 #include "UIController.h" 
+#include "Application/Commands/ApplicationCommandDispatcher.h"
 #include <stdlib.h>
 #include <string>
 #include <iostream>
@@ -724,6 +725,8 @@ void SongView::processNormalButtonMask(unsigned int mask) {
 					if (mask&EPBM_DOWN) jumpToNextSection(1) ;
 					if (mask&EPBM_UP) jumpToNextSection(-1) ;
 					if (mask&EPBM_START) startCurrentRow() ;
+					if (mask&EPBM_LEFT) nudgeTempo(-1);
+					if (mask&EPBM_RIGHT) nudgeTempo(1);
 				} else {
 
 	    			// No modifier
@@ -1106,4 +1109,18 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
 	}
 	drawNotes() ;
 } ;
+
+
+void SongView::nudgeTempo(int direction) {
+	ApplicationCommandDispatcher *dispatcher=ApplicationCommandDispatcher::GetInstance();
+	switch(direction) {
+		case -1:
+			dispatcher->OnNudgeDown();
+			break;
+		case 1:
+			dispatcher->OnNudgeUp();
+			break;
+	}
+}
+
 

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -87,6 +87,7 @@ private:
 	bool needClear_ ;
 	bool canDeepClone_;
 	uint32_t deepCloneTime;
+	void nudgeTempo(int direction) ;
 } ;
 
 #endif


### PR DESCRIPTION
Introducing the already existing, awesome, hidden and completely undocumented nudge feature!
Very useful for DJ sets when using multiple devices In Project view, select tempo and hold B+LEFT/RIGHT to nudge slower/faster In Song view, pressing LT+LEFT/RIGHT will do the same

Fixes:
  Crash when nudging below 0 BPM (shoutout @merumerutho) https://github.com/djdiskmachine/LittleGPTracker/issues/127