### PR TITLE
Fixes bug in chainview: column warping

### DIFF
--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -9,7 +9,7 @@
 bool View::initPrivate_=false ;
 
 int View::margin_=0 ;
-int View::songRowCount_ ;//=21 ;
+int View::songRowCount_; //=21 sets screen height among other things
 bool View::miniLayout_=false ;
 int View::altRowNumber_ = 4;
 
@@ -24,7 +24,7 @@ View::View(GUIWindow &w,ViewData *viewData):
 	   GUIRect rect=w.GetRect() ;
      miniLayout_=(rect.Width()<320);
 	   View::margin_=0 ;
-	   songRowCount_=miniLayout_?16:22 ;
+		songRowCount_ = miniLayout_ ? 16:22; // 22 is row display count among other things
 
 		const char *altRowStr = Config::GetInstance()->GetValue("ALTROWNUMBER");
 		if (altRowStr) {

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -86,8 +86,8 @@ void ChainView::warpInColumn(int offset) {
 	int saveY = viewData_->songY_ ;
 	int saveOffset = viewData_->songOffset_ ;
 
-	// move and check we're on valid chain
-	while (viewData_->songY_ > 0 && viewData_->songY_ < 232) {
+	// Jumping more than the rows displayed on screen causes infinite loop
+	while (viewData_->songY_ >= 0 && viewData_->songY_ < 21) {
 		viewData_->UpdateSongCursor(0,offset) ;
 		unsigned char *data=viewData_->GetCurrentSongPointer() ;
 		if (*data!=0xFF) {

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -69,8 +69,8 @@ void SongView::setChain(unsigned char value) {
 
 /******************************************************
  updateSongOffset:
-        modify top of the page row in song view by
-        adding offset parameter
+        Jump from the current position up or down
+	by [offset] rows
  ******************************************************/
  
 void SongView::updateSongOffset(int offset) {

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -632,8 +632,8 @@ void SongView::processNormalButtonMask(unsigned int mask) {
 
 	if (mask&EPBM_B) {
 
-		if (mask&EPBM_DOWN) updateSongOffset(View::songRowCount_) ;
-		if (mask&EPBM_UP) updateSongOffset(-View::songRowCount_);
+		if (mask&EPBM_DOWN) updateSongOffset(SongView::jumpLength_) ;
+		if (mask&EPBM_UP) updateSongOffset(-SongView::jumpLength_);
 		if (mask&(EPBM_RIGHT|EPBM_LEFT)) {
 		   Player *player=Player::GetInstance() ;
            switch(player->GetSequencerMode()) {

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -28,6 +28,7 @@ SongView::SongView(GUIWindow &w,ViewData *viewData,const char *song):View(w,view
 	clipboard_.data_=0 ;
 	invertBatt_=false ;
 	canDeepClone_ = false;
+	jumpLength_ = 0x10; // B-jump 16 rows like LSDJ
 }
 
 /****************

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -87,7 +87,8 @@ private:
 	bool needClear_ ;
 	bool canDeepClone_;
 	uint32_t deepCloneTime;
-	void nudgeTempo(int direction) ;
+	void nudgeTempo(int direction);
+	uint8_t jumpLength_ = 0x10; // B-jump 16 rows like LSDJ
 } ;
 
 #endif

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -88,7 +88,7 @@ private:
 	bool canDeepClone_;
 	uint32_t deepCloneTime;
 	void nudgeTempo(int direction);
-	uint8_t jumpLength_ = 0x10; // B-jump 16 rows like LSDJ
+	uint8_t jumpLength_;		  // When jumping columns with B
 } ;
 
 #endif


### PR DESCRIPTION
Jumping below lowest row would cause infinite loop
Jumping from row 0 was not possible in chainview
Limit jump to maximum lowest populated row
Set songview b jumping length to 16 rows in correspondence with LSDJ and M8