### PR TITLE
Improve Midi Input Part 1

### DIFF
--- a/projects/resources/RG35XXPLUS/mapping.xml
+++ b/projects/resources/RG35XXPLUS/mapping.xml
@@ -5,17 +5,17 @@
     enable DUMPEVENT to help with mapping
 -->
 <MAPPINGS>
-    
-    <MAP src="but:0:4" dst="/event/lshoulder" />
-    <MAP src="but:0:5" dst="/event/rshoulder" />    
 
-    <MAP src="hat:0:0:0" dst="/event/up" />
-    <MAP src="hat:0:0:2" dst="/event/down" />
-    <MAP src="hat:0:0:3" dst="/event/left" />
-    <MAP src="hat:0:0:1" dst="/event/right" />
+        <MAP src="but:0:4" dst="/event/lshoulder" />
+        <MAP src="but:0:5" dst="/event/rshoulder" />    
 
-    <MAP src="but:0:0" dst="/event/a" />
-    <MAP src="but:0:1" dst="/event/b" />    
-    <MAP src="but:0:7" dst="/event/start" />
+        <MAP src="hat:0:0:0" dst="/event/up" />
+        <MAP src="hat:0:0:2" dst="/event/down" />
+        <MAP src="hat:0:0:3" dst="/event/left" />
+        <MAP src="hat:0:0:1" dst="/event/right" />
+
+        <MAP src="but:0:0" dst="/event/a" />
+        <MAP src="but:0:1" dst="/event/b" />
+        <MAP src="but:0:7" dst="/event/start" />
 
 </MAPPINGS>

--- a/projects/resources/RG35XXPLUS/mapping.xml
+++ b/projects/resources/RG35XXPLUS/mapping.xml
@@ -6,16 +6,16 @@
 -->
 <MAPPINGS>
 
-        <MAP src="but:0:4" dst="/event/lshoulder" />
-        <MAP src="but:0:5" dst="/event/rshoulder" />    
+    <MAP src="but:0:4" dst="/event/lshoulder" />
+    <MAP src="but:0:5" dst="/event/rshoulder" />
 
-        <MAP src="hat:0:0:0" dst="/event/up" />
-        <MAP src="hat:0:0:2" dst="/event/down" />
-        <MAP src="hat:0:0:3" dst="/event/left" />
-        <MAP src="hat:0:0:1" dst="/event/right" />
+    <MAP src="hat:0:0:0" dst="/event/up" />
+    <MAP src="hat:0:0:2" dst="/event/down" />
+    <MAP src="hat:0:0:3" dst="/event/left" />
+    <MAP src="hat:0:0:1" dst="/event/right" />
 
-        <MAP src="but:0:0" dst="/event/a" />
-        <MAP src="but:0:1" dst="/event/b" />
-        <MAP src="but:0:7" dst="/event/start" />
+    <MAP src="but:0:0" dst="/event/a" />
+    <MAP src="but:0:1" dst="/event/b" />
+    <MAP src="but:0:7" dst="/event/start" />
 
 </MAPPINGS>

--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -1,48 +1,42 @@
-#include "Application.h" 
+#include "Application.h"
 
-#include <math.h>
-#include "Application/AppWindow.h" 
+#include "Application/AppWindow.h"
 #include "Application/Commands/CommandDispatcher.h"
 #include "Application/Controllers/ControlRoom.h"
 #include "Application/Model/Config.h"
-#include "Application/Persistency/PersistencyService.h" 
+#include "Application/Persistency/PersistencyService.h"
 #include "Services/Audio/Audio.h"
 #include "Services/Midi/MidiService.h"
 #include "UIFramework/Interfaces/I_GUIWindowFactory.h"
+#include <math.h>
 
+Application *Application::instance_ = NULL;
 
-Application *Application::instance_=NULL ;
+Application::Application() {}
 
-Application::Application() {
-}
-
-void Application::initMidiInput()
-{
-    const char * preferedDevice=Config::GetInstance()->GetValue("MIDICTRLDEVICE");
+void Application::initMidiInput() {
+    const char *preferedDevice =
+        Config::GetInstance()->GetValue("MIDICTRLDEVICE");
     if (preferedDevice) {
         MidiService::GetInstance()->SelectDevice(preferedDevice);
     }
 }
 
 bool Application::Init(GUICreateWindowParams &params) {
-    const char* root=Config::GetInstance()->GetValue("ROOTFOLDER") ;
+    const char *root = Config::GetInstance()->GetValue("ROOTFOLDER");
     if (root) {
-        Path::SetAlias("root",root) ;
+        Path::SetAlias("root", root);
     }
-    window_=AppWindow::Create(params) ;
-    PersistencyService::GetInstance() ;
-    Audio *audio=Audio::GetInstance() ;
-    audio->Init() ;
-    CommandDispatcher::GetInstance()->Init() ;
+    window_ = AppWindow::Create(params);
+    PersistencyService::GetInstance();
+    Audio *audio = Audio::GetInstance();
+    audio->Init();
+    CommandDispatcher::GetInstance()->Init();
     initMidiInput();
-    ControlRoom::GetInstance()->LoadMapping("bin:mapping.xml") ;
-    return true ;
+    ControlRoom::GetInstance()->LoadMapping("bin:mapping.xml");
+    return true;
 }
 
-GUIWindow *Application::GetWindow() {
-    return window_ ;
-}
+GUIWindow *Application::GetWindow() { return window_; }
 
-Application::~Application() {
-    delete window_ ;
-}
+Application::~Application() { delete window_; }

--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -18,27 +18,10 @@ Application::Application() {
 
 void Application::initMidiInput()
 {
-    const char *preferedDevice=Config::GetInstance()->GetValue("MIDICTRLDEVICE");
-
-    IteratorPtr<MidiInDevice>it(MidiService::GetInstance()->GetInIterator()) ;
-    for(it->Begin();!it->IsDone();it->Next())
-    {
-        MidiInDevice &in=it->CurrentItem() ;
-        if ((preferedDevice) && (!strncmp(in.GetName(), preferedDevice, strlen(preferedDevice))))
-        {
-            if (in.Init())
-            {
-                if (in.Start())
-                {
-                    Trace::Log("MIDI","Controlling activated for MIDI interface %s",in.GetName()) ;
-                }
-            else
-            {
-                in.Close() ;
-            }
-        }
+    const char * preferedDevice=Config::GetInstance()->GetValue("MIDICTRLDEVICE");
+    if (preferedDevice) {
+        MidiService::GetInstance()->SelectDevice(preferedDevice);
     }
-  }
 }
 
 bool Application::Init(GUICreateWindowParams &params) {

--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -1,14 +1,15 @@
-#include "Application/Application.h" 
+#include "Application.h" 
+
+#include <math.h>
 #include "Application/AppWindow.h" 
-#include "UIFramework/Interfaces/I_GUIWindowFactory.h"
-#include "Application/Persistency/PersistencyService.h" 
-#include "Services/Audio/Audio.h"
 #include "Application/Commands/CommandDispatcher.h"
 #include "Application/Controllers/ControlRoom.h"
 #include "Application/Model/Config.h"
+#include "Application/Persistency/PersistencyService.h" 
+#include "Services/Audio/Audio.h"
 #include "Services/Midi/MidiService.h"
+#include "UIFramework/Interfaces/I_GUIWindowFactory.h"
 
-#include <math.h>
 
 Application *Application::instance_=NULL ;
 
@@ -17,48 +18,48 @@ Application::Application() {
 
 void Application::initMidiInput()
 {
-  const char *preferedDevice=Config::GetInstance()->GetValue("MIDICTRLDEVICE");
+    const char *preferedDevice=Config::GetInstance()->GetValue("MIDICTRLDEVICE");
 
-  IteratorPtr<MidiInDevice>it(MidiService::GetInstance()->GetInIterator()) ;
-  for(it->Begin();!it->IsDone();it->Next())
-  {
-    MidiInDevice &in=it->CurrentItem() ;
-    if ((preferedDevice) && (!strncmp(in.GetName(), preferedDevice, strlen(preferedDevice))))
+    IteratorPtr<MidiInDevice>it(MidiService::GetInstance()->GetInIterator()) ;
+    for(it->Begin();!it->IsDone();it->Next())
     {
-      if (in.Init())
-      {
-        if (in.Start())
+        MidiInDevice &in=it->CurrentItem() ;
+        if ((preferedDevice) && (!strncmp(in.GetName(), preferedDevice, strlen(preferedDevice))))
         {
-          Trace::Log("MIDI","Controlling activated for MIDI interface %s",in.GetName()) ;
+            if (in.Init())
+            {
+                if (in.Start())
+                {
+                    Trace::Log("MIDI","Controlling activated for MIDI interface %s",in.GetName()) ;
+                }
+            else
+            {
+                in.Close() ;
+            }
         }
-        else
-        {
-          in.Close() ;
-        }
-      }
     }
   }
 }
 
 bool Application::Init(GUICreateWindowParams &params) {
-	const char* root=Config::GetInstance()->GetValue("ROOTFOLDER") ;
-	if (root) {
-		Path::SetAlias("root",root) ;
-	} ;
-	window_=AppWindow::Create(params) ;
-	PersistencyService::GetInstance() ;
-  Audio *audio=Audio::GetInstance() ;
-  audio->Init() ;
-	CommandDispatcher::GetInstance()->Init() ;
-  initMidiInput();
-	ControlRoom::GetInstance()->LoadMapping("bin:mapping.xml") ;
-	return true ;
-} ;
+    const char* root=Config::GetInstance()->GetValue("ROOTFOLDER") ;
+    if (root) {
+        Path::SetAlias("root",root) ;
+    }
+    window_=AppWindow::Create(params) ;
+    PersistencyService::GetInstance() ;
+    Audio *audio=Audio::GetInstance() ;
+    audio->Init() ;
+    CommandDispatcher::GetInstance()->Init() ;
+    initMidiInput();
+    ControlRoom::GetInstance()->LoadMapping("bin:mapping.xml") ;
+    return true ;
+}
 
 GUIWindow *Application::GetWindow() {
-	return window_ ;
-} ;
+    return window_ ;
+}
 
 Application::~Application() {
-	delete window_ ;
+    delete window_ ;
 }

--- a/sources/Application/Application.h
+++ b/sources/Application/Application.h
@@ -4,22 +4,23 @@
 #include "Foundation/T_Singleton.h"
 #include "UIFramework/SimpleBaseClasses/GUIWindow.h"
 
-class Application:public T_Singleton<Application> {
+class Application : public T_Singleton<Application> {
 
-public:
-    Application() ;
-    ~Application() ;
-    bool Init(GUICreateWindowParams &params) ;
+  public:
+    Application();
+    ~Application();
+    bool Init(GUICreateWindowParams &params);
 
-    GUIWindow *GetWindow() ;
-protected:
+    GUIWindow *GetWindow();
+
+  protected:
     void initMidiInput();
 
-private:
-    GUIWindow *window_ ;
-private:
-    static Application* instance_ ;
-} ;
+  private:
+    GUIWindow *window_;
+
+  private:
+    static Application *instance_;
+};
 
 #endif // _APPLICATION_H_
-

--- a/sources/Application/Application.h
+++ b/sources/Application/Application.h
@@ -1,25 +1,25 @@
 #ifndef _APPLICATION_H_
 #define _APPLICATION_H_
 
-#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
 #include "Foundation/T_Singleton.h"
+#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
 
 class Application:public T_Singleton<Application> {
 
 public:
-	Application() ;
-	~Application() ;
-	bool Init(GUICreateWindowParams &params) ;
+    Application() ;
+    ~Application() ;
+    bool Init(GUICreateWindowParams &params) ;
 
-	GUIWindow *GetWindow() ;
+    GUIWindow *GetWindow() ;
 protected:
-  void initMidiInput();
+    void initMidiInput();
 
 private:
-	GUIWindow *window_ ;
+    GUIWindow *window_ ;
 private:
-	static Application* instance_ ;
+    static Application* instance_ ;
 } ;
 
-#endif
+#endif // _APPLICATION_H_
 

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -1,7 +1,9 @@
 #include "MidiInDevice.h"
+
+#include "Application/Model/Config.h"
+#include "Application/Player/Player.h"
 #include "System/System/System.h"
 #include "System/Console/Trace.h"
-#include "Application/Model/Config.h"
 
 using namespace std;
 
@@ -63,21 +65,35 @@ bool MidiInDevice::IsRunning() {
 } ;
 
 void MidiInDevice::onMidiStart() {
-	MidiSyncData data(MSM_START) ;
-	SetChanged() ;
-	NotifyObservers() ;
+    MidiSyncData data(MSM_START) ;
+    SetChanged() ;
+    NotifyObservers() ;
+    
+    // SL: Question: Should this use Notifiers?
+    Player *player=Player::GetInstance() ;
+    player->Start(PM_SONG, true) ;
 } ;
 
 void MidiInDevice::onMidiContinue() {
-	MidiSyncData data(MSM_CONTINUE) ;
-	SetChanged() ;
-	NotifyObservers() ;
+    MidiSyncData data(MSM_CONTINUE) ;
+    SetChanged() ;
+    NotifyObservers() ;
+    
+    // SL: Question: Should this use Notifiers?
+    Player *player=Player::GetInstance() ;
+    // Todo: Start currently restarts playback according to
+    //       the standard it shouldn't do that.
+    player->Start(PM_SONG, false) ;
 } ;
 
 void MidiInDevice::onMidiStop() {
-	MidiSyncData data(MSM_STOP) ;
-	SetChanged() ;
-	NotifyObservers() ;
+    MidiSyncData data(MSM_STOP) ;
+    SetChanged() ;
+    NotifyObservers() ;
+    
+    // SL: Question: Should this use Notifiers?
+    Player *player=Player::GetInstance() ;
+    player->Stop() ;
 } ;
 
 void MidiInDevice::onMidiTempoTick() {

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -2,36 +2,37 @@
 
 #include "Application/Model/Config.h"
 #include "Application/Player/Player.h"
-#include "System/System/System.h"
 #include "System/Console/Trace.h"
+#include "System/System/System.h"
 
 using namespace std;
 
 bool MidiInDevice::dumpEvents_ = false;
 
-MidiInDevice::MidiInDevice(const char *name):ControllerSource("midi",name),T_Stack<MidiMessage>(true) {
+MidiInDevice::MidiInDevice(const char *name)
+    : ControllerSource("midi", name), T_Stack<MidiMessage>(true) {
 
-  const char *dumpIt=Config::GetInstance()->GetValue("DUMPEVENT");
-  dumpEvents_ = (dumpIt!=0);
+    const char *dumpIt = Config::GetInstance()->GetValue("DUMPEVENT");
+    dumpEvents_ = (dumpIt != 0);
 
     for (int channel = 0; channel < 16; channel++) {
-        for (int i=0;i<128;i++) {
+        for (int i = 0; i < 128; i++) {
             noteChannel_[channel][i] = NULL;
             ccChannel_[channel][i] = NULL;
             atChannel_[channel][i] = NULL;
         }
         pbChannel_[channel] = NULL;
         catChannel_[channel] = NULL;
-    pcChannel_[channel] = NULL;
+        pcChannel_[channel] = NULL;
     }
 
-    isRunning_=false ;
-} ;
+    isRunning_ = false;
+};
 
 MidiInDevice::~MidiInDevice() {
-    
-    for  (int channel = 0; channel < 16; channel++) {
-        for (int i=0;i<128;i++) {
+
+    for (int channel = 0; channel < 16; channel++) {
+        for (int i = 0; i < 128; i++) {
             SAFE_DELETE(noteChannel_[channel][i]);
             SAFE_DELETE(ccChannel_[channel][i]);
             SAFE_DELETE(atChannel_[channel][i]);
@@ -42,34 +43,28 @@ MidiInDevice::~MidiInDevice() {
     }
 }
 
-bool MidiInDevice::Init() {
-    return initDriver();
-}
+bool MidiInDevice::Init() { return initDriver(); }
 
-void MidiInDevice::Close() {
-    closeDriver();
-}
+void MidiInDevice::Close() { closeDriver(); }
 
 bool MidiInDevice::Start() {
-    isRunning_=true;
+    isRunning_ = true;
     return startDriver();
 }
 
 void MidiInDevice::Stop() {
-    isRunning_=false;
+    isRunning_ = false;
     stopDriver();
 }
 
-bool MidiInDevice::IsRunning() {
-    return isRunning_;
-}
+bool MidiInDevice::IsRunning() { return isRunning_; }
 
 void MidiInDevice::onMidiStart() {
     MidiSyncData data(MSM_START);
     SetChanged();
     NotifyObservers();
-    
-    Player *player=Player::GetInstance();
+
+    Player *player = Player::GetInstance();
     player->Start(PM_SONG, true);
 }
 
@@ -77,8 +72,8 @@ void MidiInDevice::onMidiContinue() {
     MidiSyncData data(MSM_CONTINUE);
     SetChanged();
     NotifyObservers();
-    
-    Player *player=Player::GetInstance();
+
+    Player *player = Player::GetInstance();
     // Todo: Start currently restarts playback according to
     //       the standard it shouldn't do that.
     player->Start(PM_SONG, false);
@@ -88,9 +83,9 @@ void MidiInDevice::onMidiStop() {
     MidiSyncData data(MSM_STOP);
     SetChanged();
     NotifyObservers();
-    
+
     // SL: Question: Should this use Notifiers?
-    Player *player=Player::GetInstance();
+    Player *player = Player::GetInstance();
     player->Stop();
 }
 
@@ -114,16 +109,16 @@ void MidiInDevice::onDriverMessage(MidiMessage &message) {
 
 void MidiInDevice::Trigger(Time time) {
 
-    MidiMessage *event=Pop(true);
+    MidiMessage *event = Pop(true);
     while (event) {
         treatChannelEvent(*event);
         delete event;
 
-        event=Pop(true);
+        event = Pop(true);
     }
 
     for (int midiChannel = 0; midiChannel < 16; midiChannel++) {
-        for (int i=0;i<128;i++) {
+        for (int i = 0; i < 128; i++) {
             if (ccChannel_[midiChannel][i]) {
                 ccChannel_[midiChannel][i]->Trigger();
             }
@@ -150,172 +145,149 @@ void MidiInDevice::treatChannelEvent(MidiMessage &event) {
 
     int midiChannel = event.status_ & 0x0F;
     bool isMidiClockEvent = (event.status_ == 0xF8);
-    
-    // Midi clock events happen alot so handle them first to make the codepath shorter
+
+    // Midi clock events happen alot so handle them first to make the codepath
+    // shorter
     if (isMidiClockEvent) {
         // Todo: SL implement midi clock
         return;
     }
-    
+
     if (!isMidiClockEvent) {
-        Trace::Debug("midi in:%X:%X:%X",event.status_, event.data1_, event.data2_);
+        Trace::Debug("midi in:%X:%X:%X", event.status_, event.data1_,
+                     event.data2_);
     }
 
-    switch (event.GetType())
-    {
-        case MidiMessage::MIDI_NOTE_OFF:
-        {
-            int note=event.data1_&0x7F;
+    switch (event.GetType()) {
+    case MidiMessage::MIDI_NOTE_OFF: {
+        int note = event.data1_ & 0x7F;
 
-            if (noteChannel_[midiChannel][note]!=0)
-            {
-                treatNoteOff(noteChannel_[midiChannel][note]);
-            }
+        if (noteChannel_[midiChannel][note] != 0) {
+            treatNoteOff(noteChannel_[midiChannel][note]);
         }
-        break;
-      
-        case MidiMessage::MIDI_NOTE_ON:
-        {
-            int note=event.data1_&0x7F;
-            int data=event.data2_&0x7F;
-            if (dumpEvents_)
-            {
-                Trace::Log("EVENT","midi:note:%d",note);
-            }
-            if (noteChannel_[midiChannel][note]!=0)
-            {
-                treatNoteOn(noteChannel_[midiChannel][note],data);
-            }
-        }
-        break;
-      
-        case MidiMessage::MIDI_AFTERTOUCH:
-        {
-            int note=event.data1_&0x7F;
-            int data=event.data2_&0x7F;
-      
-            MidiChannel* channel = atChannel_[midiChannel][note];
-            if (channel)
-            {
-                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
-                channel->Trigger();
-            }
-        }
-        break;
-      
-        case MidiMessage::MIDI_CONTROLLER:
-        {
-            int cc=event.data1_&0x7F;
-            int data=event.data2_&0x7F;
-      
-            if (dumpEvents_)
-            {
-                Trace::Log("EVENT","midi:cc:%d:%d",cc,data);
-            }
+    } break;
 
-            // First, look if we're not handling a hi nibble from a hi-res CC
-            
-            if ((cc>31)&&(ccChannel_[midiChannel][cc-32]!=0)&&(ccChannel_[midiChannel][cc-32]->IsHiRes())) {
-                treatCC(ccChannel_[midiChannel][cc-32],data);
-            } else {
-                if (ccChannel_[midiChannel][cc]!=0) {
-                    if (ccChannel_[midiChannel][cc]->IsHiRes()) {
-                        treatCC(ccChannel_[midiChannel][cc],data,true);
-                    } else {
-                        treatCC(ccChannel_[midiChannel][cc],data);
-                    }
+    case MidiMessage::MIDI_NOTE_ON: {
+        int note = event.data1_ & 0x7F;
+        int data = event.data2_ & 0x7F;
+        if (dumpEvents_) {
+            Trace::Log("EVENT", "midi:note:%d", note);
+        }
+        if (noteChannel_[midiChannel][note] != 0) {
+            treatNoteOn(noteChannel_[midiChannel][note], data);
+        }
+    } break;
+
+    case MidiMessage::MIDI_AFTERTOUCH: {
+        int note = event.data1_ & 0x7F;
+        int data = event.data2_ & 0x7F;
+
+        MidiChannel *channel = atChannel_[midiChannel][note];
+        if (channel) {
+            channel->SetValue(float(data) / (channel->GetRange() / 2.0f - 1));
+            channel->Trigger();
+        }
+    } break;
+
+    case MidiMessage::MIDI_CONTROLLER: {
+        int cc = event.data1_ & 0x7F;
+        int data = event.data2_ & 0x7F;
+
+        if (dumpEvents_) {
+            Trace::Log("EVENT", "midi:cc:%d:%d", cc, data);
+        }
+
+        // First, look if we're not handling a hi nibble from a hi-res CC
+
+        if ((cc > 31) && (ccChannel_[midiChannel][cc - 32] != 0) &&
+            (ccChannel_[midiChannel][cc - 32]->IsHiRes())) {
+            treatCC(ccChannel_[midiChannel][cc - 32], data);
+        } else {
+            if (ccChannel_[midiChannel][cc] != 0) {
+                if (ccChannel_[midiChannel][cc]->IsHiRes()) {
+                    treatCC(ccChannel_[midiChannel][cc], data, true);
+                } else {
+                    treatCC(ccChannel_[midiChannel][cc], data);
                 }
             }
         }
-        break;
-      
-        case MidiMessage::MIDI_PROGRAM_CHANGE:
-        {
-            int data=event.data1_&0x7F;
-      
-            MidiChannel* channel = pcChannel_[midiChannel];
-            if (channel)
-            {
-                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
-                channel->Trigger();
-            }
-        }
-        break;
-        
-        case MidiMessage::MIDI_CHANNEL_AFTERTOUCH:
-        {
-            int data=event.data1_&0x7F;
+    } break;
 
-            MidiChannel* channel = catChannel_[midiChannel];
-            if (channel)
-            {
-                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
-                channel->Trigger();
-            }
-        }
-        break ;
+    case MidiMessage::MIDI_PROGRAM_CHANGE: {
+        int data = event.data1_ & 0x7F;
 
-        case MidiMessage::MIDI_PITCH_BEND:
-        {
-            MidiChannel* channel = pbChannel_[midiChannel];
-            if (channel)
-            {
-                channel->SetValue((event.data2_*0x7F+event.data1_)/float(0x3F80));
-                channel->Trigger();
-            }
+        MidiChannel *channel = pcChannel_[midiChannel];
+        if (channel) {
+            channel->SetValue(float(data) / (channel->GetRange() / 2.0f - 1));
+            channel->Trigger();
         }
-        case MidiMessage::MIDI_MIDI_CLOCK: // Midi clock
-            // MIDI_START = 0xFA,
-            // MIDI_CONTINUE = 0xFB,
-            // MIDI_STOP = 0xFC,
-            switch (event.status_)
-            {
-                case 0xFA:
-                {
-                    Trace::Log("EVENT","midi:start");
-                    onMidiStart();
-                    break;
-                }
-                case 0xFB:
-                {
-                    Trace::Log("EVENT","midi:continue");
-                    onMidiContinue();
-                    break;
-                }
-                case 0xFC:
-                {
-                    Trace::Log("EVENT","midi:stop");
-                    onMidiStop();
-                    break;
-                }
-            }
+    } break;
+
+    case MidiMessage::MIDI_CHANNEL_AFTERTOUCH: {
+        int data = event.data1_ & 0x7F;
+
+        MidiChannel *channel = catChannel_[midiChannel];
+        if (channel) {
+            channel->SetValue(float(data) / (channel->GetRange() / 2.0f - 1));
+            channel->Trigger();
+        }
+    } break;
+
+    case MidiMessage::MIDI_PITCH_BEND: {
+        MidiChannel *channel = pbChannel_[midiChannel];
+        if (channel) {
+            channel->SetValue((event.data2_ * 0x7F + event.data1_) /
+                              float(0x3F80));
+            channel->Trigger();
+        }
+    }
+    case MidiMessage::MIDI_MIDI_CLOCK: // Midi clock
+        // MIDI_START = 0xFA,
+        // MIDI_CONTINUE = 0xFB,
+        // MIDI_STOP = 0xFC,
+        switch (event.status_) {
+        case 0xFA: {
+            Trace::Log("EVENT", "midi:start");
+            onMidiStart();
             break;
-        default:
+        }
+        case 0xFB: {
+            Trace::Log("EVENT", "midi:continue");
+            onMidiContinue();
             break;
+        }
+        case 0xFC: {
+            Trace::Log("EVENT", "midi:stop");
+            onMidiStop();
+            break;
+        }
+        }
+        break;
+    default:
+        break;
     }
 }
 
 Channel *MidiInDevice::GetChannel(const char *sourcePath) {
 
-    Channel *channel=0;
+    Channel *channel = 0;
 
-    string path=sourcePath;
-    string::size_type pos = path.find (":",0);
+    string path = sourcePath;
+    string::size_type pos = path.find(":", 0);
     if (pos == string::npos) {
-        return 0 ;
+        return 0;
     }
 
-    MidiChannel **ccChannel=0;
-    MidiChannel **noteChannel=0;
-    MidiChannel **pbChannel=0;
-    MidiChannel **pcChannel=0;
-    MidiChannel **catChannel=0;
-    MidiChannel **atChannel=0;
-    MidiChannel **activityChannel=0;
+    MidiChannel **ccChannel = 0;
+    MidiChannel **noteChannel = 0;
+    MidiChannel **pbChannel = 0;
+    MidiChannel **pcChannel = 0;
+    MidiChannel **catChannel = 0;
+    MidiChannel **atChannel = 0;
+    MidiChannel **activityChannel = 0;
 
-    string firstElem=path.substr(0,pos);
+    string firstElem = path.substr(0, pos);
     string type = "";
-
 
     // MIDI channel dependent channels
 
@@ -323,236 +295,245 @@ Channel *MidiInDevice::GetChannel(const char *sourcePath) {
 
     // First read the channel number
 
-    int midiChannel=atoi(midiChannelStr.c_str());
-    if ((midiChannel<0)||(midiChannel>15)) {
-        return 0 ;
-    }
-
-    // read type
-    path = path.substr(pos+1);
-    pos = path.find (":",0);
-    type = path.substr (0,pos);
-
-    // Read the event id (note, cc, pb)
-    pos = path.find (":",0);
-    path = path.substr(pos+1);
-    int id=atoi(path.c_str());
-    if ((id<0)||(id>127)) {
+    int midiChannel = atoi(midiChannelStr.c_str());
+    if ((midiChannel < 0) || (midiChannel > 15)) {
         return 0;
     }
 
-    ccChannel=&(ccChannel_[midiChannel][id]);
-    noteChannel=&(noteChannel_[midiChannel][id]);
-    pbChannel=&(pbChannel_[midiChannel]);
-    catChannel=&(catChannel_[midiChannel]);
-    atChannel=&(atChannel_[midiChannel][id]);
-    pcChannel=&(pcChannel_[midiChannel]);
+    // read type
+    path = path.substr(pos + 1);
+    pos = path.find(":", 0);
+    type = path.substr(0, pos);
 
+    // Read the event id (note, cc, pb)
+    pos = path.find(":", 0);
+    path = path.substr(pos + 1);
+    int id = atoi(path.c_str());
+    if ((id < 0) || (id > 127)) {
+        return 0;
+    }
 
-    if (type.substr(0,2)=="cc") {
+    ccChannel = &(ccChannel_[midiChannel][id]);
+    noteChannel = &(noteChannel_[midiChannel][id]);
+    pbChannel = &(pbChannel_[midiChannel]);
+    catChannel = &(catChannel_[midiChannel]);
+    atChannel = &(atChannel_[midiChannel][id]);
+    pcChannel = &(pcChannel_[midiChannel]);
 
-        MidiControllerType ccType=MCT_NONE;
-        bool isCircular=false;
-        bool isHiRes=false;
+    if (type.substr(0, 2) == "cc") {
 
-        if (type[2]!=0) {
-            switch(type[2]) {
-                case L'+':
-                    ccType=MCT_2_COMP ;
-                    break;
-                case L'|':
-                    ccType=MCT_HIRES;
-                    isHiRes=true;
-                    break;
-                case L'-':
-                    ccType=MCT_SIGNED_BIT;
-                    break;
-                case L'_':
-                    ccType=MCT_SIGNED_BIT_2;
-                    break;
-                case L'=':
-                    ccType=MCT_BIN_OFFSET;
-                    break;
-                case L'*': // backward compatibility
-                    ccType=MCT_2_COMP;
-                    isCircular=true;
-                    //assert(0);
-                    break;
+        MidiControllerType ccType = MCT_NONE;
+        bool isCircular = false;
+        bool isHiRes = false;
+
+        if (type[2] != 0) {
+            switch (type[2]) {
+            case L'+':
+                ccType = MCT_2_COMP;
+                break;
+            case L'|':
+                ccType = MCT_HIRES;
+                isHiRes = true;
+                break;
+            case L'-':
+                ccType = MCT_SIGNED_BIT;
+                break;
+            case L'_':
+                ccType = MCT_SIGNED_BIT_2;
+                break;
+            case L'=':
+                ccType = MCT_BIN_OFFSET;
+                break;
+            case L'*': // backward compatibility
+                ccType = MCT_2_COMP;
+                isCircular = true;
+                // assert(0);
+                break;
             }
-            if (type[3]!=0) {
-                NAssert(type[3]==L'*');
-                isCircular=true;
+            if (type[3] != 0) {
+                NAssert(type[3] == L'*');
+                isCircular = true;
             }
         }
 
-
-        if (*ccChannel==0) {
-            *ccChannel=new MidiChannel(sourcePath);
+        if (*ccChannel == 0) {
+            *ccChannel = new MidiChannel(sourcePath);
         }
         (*ccChannel)->SetControllerType(ccType);
         (*ccChannel)->SetCircular(isCircular);
         (*ccChannel)->SetHiRes(isHiRes);
-        channel=*ccChannel;
+        channel = *ccChannel;
     }
 
-    if (type=="note") {
-        if (*noteChannel==0) {
-            *noteChannel=new MidiChannel(sourcePath);
+    if (type == "note") {
+        if (*noteChannel == 0) {
+            *noteChannel = new MidiChannel(sourcePath);
         }
-        channel=*noteChannel;
+        channel = *noteChannel;
     }
-    if (type=="note+") {
-        if (*noteChannel==0) {
-            *noteChannel=new MidiChannel(sourcePath);
+    if (type == "note+") {
+        if (*noteChannel == 0) {
+            *noteChannel = new MidiChannel(sourcePath);
             (*noteChannel)->SetToggle(true);
         }
-        channel=*noteChannel;
+        channel = *noteChannel;
     }
-    if (type=="at") {
-        if (*atChannel==0) {
-            (*atChannel)=new MidiChannel(sourcePath);
+    if (type == "at") {
+        if (*atChannel == 0) {
+            (*atChannel) = new MidiChannel(sourcePath);
         }
-        channel=*atChannel;
+        channel = *atChannel;
     }
-    if (type=="pb") {
-        if (*pbChannel==0) {
-            *pbChannel=new MidiChannel(sourcePath);
+    if (type == "pb") {
+        if (*pbChannel == 0) {
+            *pbChannel = new MidiChannel(sourcePath);
         }
-        channel=*pbChannel;
+        channel = *pbChannel;
     }
-    if (type=="cat") {
-        if (*catChannel==0) {
-            *catChannel=new MidiChannel(sourcePath);
+    if (type == "cat") {
+        if (*catChannel == 0) {
+            *catChannel = new MidiChannel(sourcePath);
         }
-        channel=*catChannel;
+        channel = *catChannel;
     }
-    if (type=="pc") {
-        if (*catChannel==0) {
-            *catChannel=new MidiChannel(sourcePath);
+    if (type == "pc") {
+        if (*catChannel == 0) {
+            *catChannel = new MidiChannel(sourcePath);
         }
-        channel=*pcChannel;
+        channel = *pcChannel;
     }
-    if (type=="activity") {
-        if (*activityChannel==0) {
-            *activityChannel=new MidiChannel(sourcePath);
+    if (type == "activity") {
+        if (*activityChannel == 0) {
+            *activityChannel = new MidiChannel(sourcePath);
         }
-        channel=*activityChannel;
+        channel = *activityChannel;
     }
     return channel;
 }
 
-void MidiInDevice::treatCC(MidiChannel *channel,int data,bool hiNibble) {
-    switch(channel->GetControllerType()) {
-        // Regular midi channels
-        case MCT_NONE: // to cope with the fact we want to have the possibility to map
-                       // MIDI controllers to 0.5,0.25, etc, we map differently if data
-                       // is zero or otherwise.
+void MidiInDevice::treatCC(MidiChannel *channel, int data, bool hiNibble) {
+    switch (channel->GetControllerType()) {
+    // Regular midi channels
+    case MCT_NONE: // to cope with the fact we want to have the possibility to
+                   // map MIDI controllers to 0.5,0.25, etc, we map differently
+                   // if data is zero or otherwise.
 
-            channel->SetValue((data>0)?float(data+1)/(channel->GetRange()/2.0f):0);
-            break;
-        case MCT_HIRES:
-        {
-            float channelValue=channel->GetValue();
-            int current=(channelValue==0)?0:int(channelValue*16384-1);
-            int hi=current/128;
-            int low=current-hi*128;
-            if (hiNibble) {
-                hi=data;
-            } else {
-                low=data;
-            }
-            current=hi*128+low;
-            channel->SetValue((current==0)?0:(current+1)/16384.0f);
-            }
-            break;
-        case MCT_2_COMP:
-        {
-            float current=channel->GetValue();
-            int incr=0;
-            if (data!=0)  {
-                if (data<0x41) {
-                    incr=data;
-                } else {
-                    incr=data-0x80;
-                }
-            }
-            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
-            if (channel->IsCircular()) {
-                if (current>1.0) current-=1.0F;
-                if (current<0.0) current+=1.0F;                        
-            } else {
-                if (current>1.0) current=1.0F;
-                if (current<0.0) current=0.0F;
-            }
-            channel->SetValue(current);
-            break ;
+        channel->SetValue(
+            (data > 0) ? float(data + 1) / (channel->GetRange() / 2.0f) : 0);
+        break;
+    case MCT_HIRES: {
+        float channelValue = channel->GetValue();
+        int current = (channelValue == 0) ? 0 : int(channelValue * 16384 - 1);
+        int hi = current / 128;
+        int low = current - hi * 128;
+        if (hiNibble) {
+            hi = data;
+        } else {
+            low = data;
         }
-        case MCT_SIGNED_BIT:
-        {
-            float current=channel->GetValue();
-            int incr=0;
-            if (data!=0)  {
-                if (data<0x41) {
-                    incr=data;
-                } else {
-                    incr=0x40-data;
-                }
-            }
-            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
-            if (channel->IsCircular()) {
-                if (current>1.0) current-=1.0F;
-                if (current<0.0) current+=1.0F;                        
+        current = hi * 128 + low;
+        channel->SetValue((current == 0) ? 0 : (current + 1) / 16384.0f);
+    } break;
+    case MCT_2_COMP: {
+        float current = channel->GetValue();
+        int incr = 0;
+        if (data != 0) {
+            if (data < 0x41) {
+                incr = data;
             } else {
-                if (current>1.0) current=1.0F;
-                if (current<0.0) current=0.0F;
+                incr = data - 0x80;
             }
-            channel->SetValue(current);
-            break;
         }
-        case MCT_SIGNED_BIT_2:
-        {
-            float current=channel->GetValue();
-            int incr=0;
-            if (data!=0)  {
-                if (data<0x41) {
-                    incr=-data;
-                } else {
-                    incr=data-0x40;
-                }
-            }
-            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
-            if (channel->IsCircular()) {
-                if (current>1.0) current-=1.0F;
-                if (current<0.0) current+=1.0F;                        
+        current += float(incr) / (channel->GetRange() / 2.0f - 1.0f);
+        if (channel->IsCircular()) {
+            if (current > 1.0)
+                current -= 1.0F;
+            if (current < 0.0)
+                current += 1.0F;
+        } else {
+            if (current > 1.0)
+                current = 1.0F;
+            if (current < 0.0)
+                current = 0.0F;
+        }
+        channel->SetValue(current);
+        break;
+    }
+    case MCT_SIGNED_BIT: {
+        float current = channel->GetValue();
+        int incr = 0;
+        if (data != 0) {
+            if (data < 0x41) {
+                incr = data;
             } else {
-                if (current>1.0) current=1.0F;
-                if (current<0.0) current=0.0F;
+                incr = 0x40 - data;
             }
-            channel->SetValue(current);
-            break;
         }
-        case MCT_BIN_OFFSET:
-        {
-            float current=channel->GetValue();
-            int incr=0;
-            if (data!=0)  {
-                if (data<0x41) {
-                    incr=data-0x40;
-                } else {
-                    incr=data-0x40;
-                } ;
-            } ;
-            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
-            if (channel->IsCircular()) {
-                if (current>1.0) current-=1.0F;
-                if (current<0.0) current+=1.0F;                        
+        current += float(incr) / (channel->GetRange() / 2.0f - 1.0f);
+        if (channel->IsCircular()) {
+            if (current > 1.0)
+                current -= 1.0F;
+            if (current < 0.0)
+                current += 1.0F;
+        } else {
+            if (current > 1.0)
+                current = 1.0F;
+            if (current < 0.0)
+                current = 0.0F;
+        }
+        channel->SetValue(current);
+        break;
+    }
+    case MCT_SIGNED_BIT_2: {
+        float current = channel->GetValue();
+        int incr = 0;
+        if (data != 0) {
+            if (data < 0x41) {
+                incr = -data;
             } else {
-                if (current>1.0) current=1.0F;
-                if (current<0.0) current=0.0F;
+                incr = data - 0x40;
             }
-            channel->SetValue(current);
-            break;
         }
+        current += float(incr) / (channel->GetRange() / 2.0f - 1.0f);
+        if (channel->IsCircular()) {
+            if (current > 1.0)
+                current -= 1.0F;
+            if (current < 0.0)
+                current += 1.0F;
+        } else {
+            if (current > 1.0)
+                current = 1.0F;
+            if (current < 0.0)
+                current = 0.0F;
+        }
+        channel->SetValue(current);
+        break;
+    }
+    case MCT_BIN_OFFSET: {
+        float current = channel->GetValue();
+        int incr = 0;
+        if (data != 0) {
+            if (data < 0x41) {
+                incr = data - 0x40;
+            } else {
+                incr = data - 0x40;
+            };
+        };
+        current += float(incr) / (channel->GetRange() / 2.0f - 1.0f);
+        if (channel->IsCircular()) {
+            if (current > 1.0)
+                current -= 1.0F;
+            if (current < 0.0)
+                current += 1.0F;
+        } else {
+            if (current > 1.0)
+                current = 1.0F;
+            if (current < 0.0)
+                current = 0.0F;
+        }
+        channel->SetValue(current);
+        break;
+    }
     }
     channel->Trigger();
 }
@@ -564,8 +545,8 @@ void MidiInDevice::treatNoteOff(MidiChannel *channel) {
     channel->Trigger();
 }
 
-void MidiInDevice::treatNoteOn(MidiChannel *channel,int data) {
-    if (data==0) { // Actually a note off
+void MidiInDevice::treatNoteOn(MidiChannel *channel, int data) {
+    if (data == 0) { // Actually a note off
         if (!channel->IsToggle()) {
             channel->SetValue(0.0F);
         }
@@ -573,8 +554,8 @@ void MidiInDevice::treatNoteOn(MidiChannel *channel,int data) {
         if (!channel->IsToggle()) {
             channel->SetValue(1.0F);
         } else {
-            float current=channel->GetValue();
-            channel->SetValue((current>0.5)?0.0f:1.0f);
+            float current = channel->GetValue();
+            channel->SetValue((current > 0.5) ? 0.0f : 1.0f);
         };
     }
     channel->Trigger();

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -61,7 +61,7 @@ void MidiInDevice::Stop() {
 bool MidiInDevice::IsRunning() {
 	return isRunning_ ;
 } ;
-/*
+
 void MidiInDevice::onMidiStart() {
 	MidiSyncData data(MSM_START) ;
 	SetChanged() ;
@@ -80,6 +80,7 @@ void MidiInDevice::onMidiTempoTick() {
 	NotifyObservers() ;
 } ;
 
+/*
 void MidiInDevice::queueEvent(MidiEvent &event) {
 	T_Stack<MidiEvent>::Insert(event) ;
 } ;

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -11,564 +11,556 @@ bool MidiInDevice::dumpEvents_ = false;
 
 MidiInDevice::MidiInDevice(const char *name):ControllerSource("midi",name),T_Stack<MidiMessage>(true) {
 
-  const char *dumpIt=Config::GetInstance()->GetValue("DUMPEVENT") ;
+  const char *dumpIt=Config::GetInstance()->GetValue("DUMPEVENT");
   dumpEvents_ = (dumpIt!=0);
 
-	for (int channel = 0; channel < 16; channel++) {
-		for (int i=0;i<128;i++) {
-			noteChannel_[channel][i] = NULL;
-			ccChannel_[channel][i] = NULL;
-			atChannel_[channel][i] = NULL;
-		}
-		pbChannel_[channel] = NULL;
-		catChannel_[channel] = NULL;
+    for (int channel = 0; channel < 16; channel++) {
+        for (int i=0;i<128;i++) {
+            noteChannel_[channel][i] = NULL;
+            ccChannel_[channel][i] = NULL;
+            atChannel_[channel][i] = NULL;
+        }
+        pbChannel_[channel] = NULL;
+        catChannel_[channel] = NULL;
     pcChannel_[channel] = NULL;
-	}
+    }
 
-	isRunning_=false ;
+    isRunning_=false ;
 } ;
 
 MidiInDevice::~MidiInDevice() {
-	
-	for  (int channel = 0; channel < 16; channel++) {
-		for (int i=0;i<128;i++) {
-			SAFE_DELETE(noteChannel_[channel][i]);
-			SAFE_DELETE(ccChannel_[channel][i]);
-			SAFE_DELETE(atChannel_[channel][i]);
-		}
-		SAFE_DELETE(pbChannel_[channel]);
-		SAFE_DELETE(catChannel_[channel]);
-		SAFE_DELETE(pcChannel_[channel]);
-	}
-} ;
+    
+    for  (int channel = 0; channel < 16; channel++) {
+        for (int i=0;i<128;i++) {
+            SAFE_DELETE(noteChannel_[channel][i]);
+            SAFE_DELETE(ccChannel_[channel][i]);
+            SAFE_DELETE(atChannel_[channel][i]);
+        }
+        SAFE_DELETE(pbChannel_[channel]);
+        SAFE_DELETE(catChannel_[channel]);
+        SAFE_DELETE(pcChannel_[channel]);
+    }
+}
 
 bool MidiInDevice::Init() {
-	return initDriver() ;
-} ;
+    return initDriver();
+}
 
 void MidiInDevice::Close() {
-	closeDriver() ;
-} ;
+    closeDriver();
+}
 
 bool MidiInDevice::Start() {
-	isRunning_=true ;
-	return startDriver() ;
-} ;
+    isRunning_=true;
+    return startDriver();
+}
 
 void MidiInDevice::Stop() {
-	isRunning_=false ;
-	stopDriver() ;
-} ;
+    isRunning_=false;
+    stopDriver();
+}
 
 bool MidiInDevice::IsRunning() {
-	return isRunning_ ;
-} ;
+    return isRunning_;
+}
 
 void MidiInDevice::onMidiStart() {
-    MidiSyncData data(MSM_START) ;
-    SetChanged() ;
-    NotifyObservers() ;
+    MidiSyncData data(MSM_START);
+    SetChanged();
+    NotifyObservers();
     
-    // SL: Question: Should this use Notifiers?
-    Player *player=Player::GetInstance() ;
-    player->Start(PM_SONG, true) ;
-} ;
+    Player *player=Player::GetInstance();
+    player->Start(PM_SONG, true);
+}
 
 void MidiInDevice::onMidiContinue() {
-    MidiSyncData data(MSM_CONTINUE) ;
-    SetChanged() ;
-    NotifyObservers() ;
+    MidiSyncData data(MSM_CONTINUE);
+    SetChanged();
+    NotifyObservers();
     
-    // SL: Question: Should this use Notifiers?
-    Player *player=Player::GetInstance() ;
+    Player *player=Player::GetInstance();
     // Todo: Start currently restarts playback according to
     //       the standard it shouldn't do that.
-    player->Start(PM_SONG, false) ;
-} ;
+    player->Start(PM_SONG, false);
+}
 
 void MidiInDevice::onMidiStop() {
-    MidiSyncData data(MSM_STOP) ;
-    SetChanged() ;
-    NotifyObservers() ;
+    MidiSyncData data(MSM_STOP);
+    SetChanged();
+    NotifyObservers();
     
     // SL: Question: Should this use Notifiers?
-    Player *player=Player::GetInstance() ;
-    player->Stop() ;
-} ;
+    Player *player=Player::GetInstance();
+    player->Stop();
+}
 
 void MidiInDevice::onMidiTempoTick() {
-	MidiSyncData data(MSM_TEMPOTICK) ;
-	SetChanged() ;
-	NotifyObservers() ;
-} ;
+    MidiSyncData data(MSM_TEMPOTICK);
+    SetChanged();
+    NotifyObservers();
+}
 
 /*
 void MidiInDevice::queueEvent(MidiEvent &event) {
-	T_Stack<MidiEvent>::Insert(event) ;
+    T_Stack<MidiEvent>::Insert(event) ;
 } ;
 */
 
 void MidiInDevice::onDriverMessage(MidiMessage &message) {
-	SetChanged() ;
-	NotifyObservers(&message) ;
-	treatChannelEvent(message) ;
-} ;
+    SetChanged();
+    NotifyObservers(&message);
+    treatChannelEvent(message);
+}
 
 void MidiInDevice::Trigger(Time time) {
 
-	MidiMessage *event=Pop(true) ;
-	while (event) {
-		treatChannelEvent(*event) ;
-		delete event ;
+    MidiMessage *event=Pop(true);
+    while (event) {
+        treatChannelEvent(*event);
+        delete event;
 
-		event=Pop(true) ;
-	} ;
+        event=Pop(true);
+    }
 
-
-
-	for (int midiChannel = 0; midiChannel < 16; midiChannel++) {
-		for (int i=0;i<128;i++) {
-			if (ccChannel_[midiChannel][i]) {
-				ccChannel_[midiChannel][i]->Trigger() ;
-			} ;
-			if (noteChannel_[midiChannel][i]) {
-				noteChannel_[midiChannel][i]->Trigger() ;
-			}
-			if (atChannel_[midiChannel][i]) {
-				atChannel_[midiChannel][i]->Trigger() ;
-			}
-		} ;
-		if (pbChannel_[midiChannel]) {
-			pbChannel_[midiChannel]->Trigger() ;
-		} ;
-		if (pcChannel_[midiChannel]) {
-			pcChannel_[midiChannel]->Trigger() ;
-		}
-		if (catChannel_[midiChannel]) {
-			catChannel_[midiChannel]->Trigger() ;
-		} ;
-	}
-} ;
+    for (int midiChannel = 0; midiChannel < 16; midiChannel++) {
+        for (int i=0;i<128;i++) {
+            if (ccChannel_[midiChannel][i]) {
+                ccChannel_[midiChannel][i]->Trigger();
+            }
+            if (noteChannel_[midiChannel][i]) {
+                noteChannel_[midiChannel][i]->Trigger();
+            }
+            if (atChannel_[midiChannel][i]) {
+                atChannel_[midiChannel][i]->Trigger();
+            }
+        }
+        if (pbChannel_[midiChannel]) {
+            pbChannel_[midiChannel]->Trigger();
+        }
+        if (pcChannel_[midiChannel]) {
+            pcChannel_[midiChannel]->Trigger();
+        }
+        if (catChannel_[midiChannel]) {
+            catChannel_[midiChannel]->Trigger();
+        }
+    }
+}
 
 void MidiInDevice::treatChannelEvent(MidiMessage &event) {
 
-	int midiChannel = event.status_ & 0x0F;
+    int midiChannel = event.status_ & 0x0F;
 
-	bool isMidiClockEvent = (event.status_ == 0xF8);
+    bool isMidiClockEvent = (event.status_ == 0xF8);
 
-	switch (event.GetType())
-  {
-    case MidiMessage::MIDI_NOTE_OFF:
-		{
-			int note=event.data1_&0x7F ;
+    switch (event.GetType())
+    {
+        case MidiMessage::MIDI_NOTE_OFF:
+        {
+            int note=event.data1_&0x7F;
 
-			if (noteChannel_[midiChannel][note]!=0)
-      {
-				treatNoteOff(noteChannel_[midiChannel][note]) ;
-			}
-		}
-		break;
+            if (noteChannel_[midiChannel][note]!=0)
+            {
+                treatNoteOff(noteChannel_[midiChannel][note]);
+            }
+        }
+        break;
       
-		case MidiMessage::MIDI_NOTE_ON:
-		{
-			int note=event.data1_&0x7F ;
-			int data=event.data2_&0x7F ;
-      if (dumpEvents_)
-      {
-        Trace::Log("EVENT","midi:note:%d",note) ;
-      }
-			if (noteChannel_[midiChannel][note]!=0)
-      {
-				treatNoteOn(noteChannel_[midiChannel][note],data) ;
-			}
-		}
-		break;
+        case MidiMessage::MIDI_NOTE_ON:
+        {
+            int note=event.data1_&0x7F;
+            int data=event.data2_&0x7F;
+            if (dumpEvents_)
+            {
+                Trace::Log("EVENT","midi:note:%d",note);
+            }
+            if (noteChannel_[midiChannel][note]!=0)
+            {
+                treatNoteOn(noteChannel_[midiChannel][note],data);
+            }
+        }
+        break;
       
-		case MidiMessage::MIDI_AFTERTOUCH:
-		{
-			int note=event.data1_&0x7F ;
-			int data=event.data2_&0x7F ;
+        case MidiMessage::MIDI_AFTERTOUCH:
+        {
+            int note=event.data1_&0x7F;
+            int data=event.data2_&0x7F;
       
-      MidiChannel* channel = atChannel_[midiChannel][note];
-			if (channel)
-      {
-				channel->SetValue(float(data)/(channel->GetRange()/2.0f-1)) ;
-        channel->Trigger();
-			}
-		}
-		break ;
+            MidiChannel* channel = atChannel_[midiChannel][note];
+            if (channel)
+            {
+                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
+                channel->Trigger();
+            }
+        }
+        break;
       
+        case MidiMessage::MIDI_CONTROLLER:
+        {
+            int cc=event.data1_&0x7F;
+            int data=event.data2_&0x7F;
       
-		case MidiMessage::MIDI_CONTROLLER:
-		{
-			int cc=event.data1_&0x7F ;
-			int data=event.data2_&0x7F ;
-      
-      if (dumpEvents_)
-      {
-        Trace::Log("EVENT","midi:cc:%d:%d",cc,data) ;
-      }
+            if (dumpEvents_)
+            {
+                Trace::Log("EVENT","midi:cc:%d:%d",cc,data);
+            }
 
-			// First, look if we're not handling a hi nibble from a hi-res CC
-			
-			if ((cc>31)&&(ccChannel_[midiChannel][cc-32]!=0)&&(ccChannel_[midiChannel][cc-32]->IsHiRes())) {
-				treatCC(ccChannel_[midiChannel][cc-32],data) ;
-			} else {
-				if (ccChannel_[midiChannel][cc]!=0) {
-					if (ccChannel_[midiChannel][cc]->IsHiRes()) {
-						treatCC(ccChannel_[midiChannel][cc],data,true) ;
-					} else {
-						treatCC(ccChannel_[midiChannel][cc],data) ;
-					}
-				} ;
-			}
-		}
-      break;
+            // First, look if we're not handling a hi nibble from a hi-res CC
+            
+            if ((cc>31)&&(ccChannel_[midiChannel][cc-32]!=0)&&(ccChannel_[midiChannel][cc-32]->IsHiRes())) {
+                treatCC(ccChannel_[midiChannel][cc-32],data);
+            } else {
+                if (ccChannel_[midiChannel][cc]!=0) {
+                    if (ccChannel_[midiChannel][cc]->IsHiRes()) {
+                        treatCC(ccChannel_[midiChannel][cc],data,true);
+                    } else {
+                        treatCC(ccChannel_[midiChannel][cc],data);
+                    }
+                }
+            }
+        }
+        break;
       
-		case MidiMessage::MIDI_PROGRAM_CHANGE:
-		{
-			int data=event.data1_&0x7F ;
+        case MidiMessage::MIDI_PROGRAM_CHANGE:
+        {
+            int data=event.data1_&0x7F;
       
-      MidiChannel* channel = pcChannel_[midiChannel];
-			if (channel)
-      {
-				channel->SetValue(float(data)/(channel->GetRange()/2.0f-1)) ;
-        channel->Trigger();
-			}
-		}
-      break ;
-		
-    case MidiMessage::MIDI_CHANNEL_AFTERTOUCH:
-		{
-			int data=event.data1_&0x7F ;
+            MidiChannel* channel = pcChannel_[midiChannel];
+            if (channel)
+            {
+                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
+                channel->Trigger();
+            }
+        }
+        break;
+        
+        case MidiMessage::MIDI_CHANNEL_AFTERTOUCH:
+        {
+            int data=event.data1_&0x7F;
 
-      MidiChannel* channel = catChannel_[midiChannel];
-			if (channel)
-      {
-				channel->SetValue(float(data)/(channel->GetRange()/2.0f-1)) ;
-        channel->Trigger();
-			}
-		}
-		break ;
+            MidiChannel* channel = catChannel_[midiChannel];
+            if (channel)
+            {
+                channel->SetValue(float(data)/(channel->GetRange()/2.0f-1));
+                channel->Trigger();
+            }
+        }
+        break ;
 
-		case MidiMessage::MIDI_PITCH_BEND:
-		{
-      MidiChannel* channel = pbChannel_[midiChannel];
-			if (channel)
-      {
-				channel->SetValue((event.data2_*0x7F+event.data1_)/float(0x3F80)) ;
-        channel->Trigger();
-			} ;
-		}
+        case MidiMessage::MIDI_PITCH_BEND:
+        {
+            MidiChannel* channel = pbChannel_[midiChannel];
+            if (channel)
+            {
+                channel->SetValue((event.data2_*0x7F+event.data1_)/float(0x3F80));
+                channel->Trigger();
+            }
+        }
         case MidiMessage::MIDI_START:
         {
-            Trace::Log("EVENT","midi:start") ;
+            Trace::Log("EVENT","midi:start");
             onMidiStart();
             break;
         }
         case MidiMessage::MIDI_CONTINUE:
         {
-            Trace::Log("EVENT","midi:continue") ;
+            Trace::Log("EVENT","midi:continue");
             onMidiContinue();
             break;
         }
         case MidiMessage::MIDI_STOP:
         {
-            Trace::Log("EVENT","midi:stop") ;
+            Trace::Log("EVENT","midi:stop");
             onMidiStop();
             break;
         }
-		case 0xF0: // Midi clock
-			break ;
-		default:
-			break;
-	} ;
-} ;
+        case 0xF0: // Midi clock
+            break;
+        default:
+            break;
+    }
+}
 
 Channel *MidiInDevice::GetChannel(const char *sourcePath) {
 
-	Channel *channel=0 ;
+    Channel *channel=0;
 
-	string path=sourcePath ;
-	string::size_type pos = path.find (":",0);
-	if (pos == string::npos) {
-		return 0 ;
-	} ;
+    string path=sourcePath;
+    string::size_type pos = path.find (":",0);
+    if (pos == string::npos) {
+        return 0 ;
+    }
 
+    MidiChannel **ccChannel=0;
+    MidiChannel **noteChannel=0;
+    MidiChannel **pbChannel=0;
+    MidiChannel **pcChannel=0;
+    MidiChannel **catChannel=0;
+    MidiChannel **atChannel=0;
+    MidiChannel **activityChannel=0;
 
-	MidiChannel **ccChannel=0 ;
-	MidiChannel **noteChannel=0 ;
-	MidiChannel **pbChannel=0 ;
-	MidiChannel **pcChannel=0 ;
-	MidiChannel **catChannel=0 ;
-	MidiChannel **atChannel=0 ;
-	MidiChannel **activityChannel=0 ;
-
-	string firstElem=path.substr (0,pos);
-	string type ="" ;
-
+    string firstElem=path.substr(0,pos);
+    string type = "";
 
 
-	// MIDI channel dependent channels
+    // MIDI channel dependent channels
 
-	string &midiChannelStr = firstElem;
+    string &midiChannelStr = firstElem;
 
-	// First read the channel number
+    // First read the channel number
 
-	int midiChannel=atoi(midiChannelStr.c_str()) ;
-	if ((midiChannel<0)||(midiChannel>15)) {
-		return 0 ;
-	} ;
-	 ;
+    int midiChannel=atoi(midiChannelStr.c_str());
+    if ((midiChannel<0)||(midiChannel>15)) {
+        return 0 ;
+    }
 
-	// read type
-	path = path.substr(pos+1) ;
-	pos = path.find (":",0);
-	type = path.substr (0,pos);
+    // read type
+    path = path.substr(pos+1);
+    pos = path.find (":",0);
+    type = path.substr (0,pos);
 
-	// Read the event id (note, cc, pb)
-	pos = path.find (":",0);
-	path = path.substr(pos+1) ;
-	int id=atoi(path.c_str()) ;
-	if ((id<0)||(id>127)) {
-		return 0 ;
-	} ;
+    // Read the event id (note, cc, pb)
+    pos = path.find (":",0);
+    path = path.substr(pos+1);
+    int id=atoi(path.c_str());
+    if ((id<0)||(id>127)) {
+        return 0;
+    }
 
-	ccChannel=&(ccChannel_[midiChannel][id]);
-	noteChannel=&(noteChannel_[midiChannel][id]);
-	pbChannel=&(pbChannel_[midiChannel]);
-	catChannel=&(catChannel_[midiChannel]);
-	atChannel=&(atChannel_[midiChannel][id]);
-	pcChannel=&(pcChannel_[midiChannel]);
-
-
-	if (type.substr(0,2)=="cc") {
-
-		MidiControllerType ccType=MCT_NONE ;
-		bool isCircular=false ;
-		bool isHiRes=false ;
-
-		if (type[2]!=0) {
-			switch(type[2]) {
-				case L'+':
-					ccType=MCT_2_COMP ;
-					break ;
-				case L'|':
-					ccType=MCT_HIRES;
-					isHiRes=true ;
-					break ;
-				case L'-':
-					ccType=MCT_SIGNED_BIT;
-					break ;
-				case L'_':
-					ccType=MCT_SIGNED_BIT_2;
-					break ;
-				case L'=':
-					ccType=MCT_BIN_OFFSET;
-					break ;
-				case L'*': // backward compatibility
-					ccType=MCT_2_COMP ;
-					isCircular=true ;
-					//assert(0) ;
-					break ;
-			}
-			if (type[3]!=0) {
-				NAssert(type[3]==L'*') ;
-				isCircular=true ;
-			} ;
-		} ;
+    ccChannel=&(ccChannel_[midiChannel][id]);
+    noteChannel=&(noteChannel_[midiChannel][id]);
+    pbChannel=&(pbChannel_[midiChannel]);
+    catChannel=&(catChannel_[midiChannel]);
+    atChannel=&(atChannel_[midiChannel][id]);
+    pcChannel=&(pcChannel_[midiChannel]);
 
 
-		if (*ccChannel==0) {
-			*ccChannel=new MidiChannel(sourcePath) ;
-		}
-		(*ccChannel)->SetControllerType(ccType) ;
-		(*ccChannel)->SetCircular(isCircular) ;
-		(*ccChannel)->SetHiRes(isHiRes) ;
-		channel=*ccChannel ;
-	} ;
+    if (type.substr(0,2)=="cc") {
 
-	if (type=="note") {
-		if (*noteChannel==0) {
-			*noteChannel=new MidiChannel(sourcePath) ;
-		};
-		channel=*noteChannel ;
-	} ;
-	if (type=="note+") {
-		if (*noteChannel==0) {
-			*noteChannel=new MidiChannel(sourcePath) ;
-			(*noteChannel)->SetToggle(true) ;
-		};
-		channel=*noteChannel ;
-	} ;
-	if (type=="at") {
-		if (*atChannel==0) {
-			(*atChannel)=new MidiChannel(sourcePath) ;
-		};
-		channel=*atChannel ;
-	} ;
-	if (type=="pb") {
-		if (*pbChannel==0) {
-			*pbChannel=new MidiChannel(sourcePath) ;
-		};
-		channel=*pbChannel ;
-	} ;
-	if (type=="cat") {
-		if (*catChannel==0) {
-			*catChannel=new MidiChannel(sourcePath) ;
-		};
-		channel=*catChannel ;
-	} ;
-	if (type=="pc") {
-		if (*catChannel==0) {
-			*catChannel=new MidiChannel(sourcePath) ;
-		};
-		channel=*pcChannel ;
-	} ;
-	if (type=="activity") {
-		if (*activityChannel==0) {
-			*activityChannel=new MidiChannel(sourcePath) ;
-		};
-		channel=*activityChannel ;
-	} ;
-	return channel ; ;
-} ;
+        MidiControllerType ccType=MCT_NONE;
+        bool isCircular=false;
+        bool isHiRes=false;
+
+        if (type[2]!=0) {
+            switch(type[2]) {
+                case L'+':
+                    ccType=MCT_2_COMP ;
+                    break;
+                case L'|':
+                    ccType=MCT_HIRES;
+                    isHiRes=true;
+                    break;
+                case L'-':
+                    ccType=MCT_SIGNED_BIT;
+                    break;
+                case L'_':
+                    ccType=MCT_SIGNED_BIT_2;
+                    break;
+                case L'=':
+                    ccType=MCT_BIN_OFFSET;
+                    break;
+                case L'*': // backward compatibility
+                    ccType=MCT_2_COMP;
+                    isCircular=true;
+                    //assert(0);
+                    break;
+            }
+            if (type[3]!=0) {
+                NAssert(type[3]==L'*');
+                isCircular=true;
+            }
+        }
+
+
+        if (*ccChannel==0) {
+            *ccChannel=new MidiChannel(sourcePath);
+        }
+        (*ccChannel)->SetControllerType(ccType);
+        (*ccChannel)->SetCircular(isCircular);
+        (*ccChannel)->SetHiRes(isHiRes);
+        channel=*ccChannel;
+    }
+
+    if (type=="note") {
+        if (*noteChannel==0) {
+            *noteChannel=new MidiChannel(sourcePath);
+        }
+        channel=*noteChannel;
+    }
+    if (type=="note+") {
+        if (*noteChannel==0) {
+            *noteChannel=new MidiChannel(sourcePath);
+            (*noteChannel)->SetToggle(true);
+        }
+        channel=*noteChannel;
+    }
+    if (type=="at") {
+        if (*atChannel==0) {
+            (*atChannel)=new MidiChannel(sourcePath);
+        }
+        channel=*atChannel;
+    }
+    if (type=="pb") {
+        if (*pbChannel==0) {
+            *pbChannel=new MidiChannel(sourcePath);
+        }
+        channel=*pbChannel;
+    }
+    if (type=="cat") {
+        if (*catChannel==0) {
+            *catChannel=new MidiChannel(sourcePath);
+        }
+        channel=*catChannel;
+    }
+    if (type=="pc") {
+        if (*catChannel==0) {
+            *catChannel=new MidiChannel(sourcePath);
+        }
+        channel=*pcChannel;
+    }
+    if (type=="activity") {
+        if (*activityChannel==0) {
+            *activityChannel=new MidiChannel(sourcePath);
+        }
+        channel=*activityChannel;
+    }
+    return channel;
+}
 
 void MidiInDevice::treatCC(MidiChannel *channel,int data,bool hiNibble) {
-	switch(channel->GetControllerType()) {
-		// Regular midi channels
-		case MCT_NONE: // to cope with the fact we want to have the possibility to map
-					   // MIDI controllers to 0.5,0.25, etc, we map differently if data
-					   // is zero or otherwise.
+    switch(channel->GetControllerType()) {
+        // Regular midi channels
+        case MCT_NONE: // to cope with the fact we want to have the possibility to map
+                       // MIDI controllers to 0.5,0.25, etc, we map differently if data
+                       // is zero or otherwise.
 
-			channel->SetValue((data>0)?float(data+1)/(channel->GetRange()/2.0f):0) ;
-			break ;
-		case MCT_HIRES:
-			{
-			float channelValue=channel->GetValue() ;
-			int current=(channelValue==0)?0:int(channelValue*16384-1) ;
-			int hi=current/128 ;
-			int low=current-hi*128 ;
-			if (hiNibble) {
-				hi=data ;
-			} else {
-				low=data ;
-			}
-			current=hi*128+low ;
-			channel->SetValue((current==0)?0:(current+1)/16384.0f) ;
-			}
-			break ;
-		case MCT_2_COMP:
-		{
-			float current=channel->GetValue() ;
-			int incr=0 ;
-			if (data!=0)  {
-				if (data<0x41) {
-					incr=data ;
-				} else {
-					incr=data-0x80 ;
-				} ;
-			} ;
-			current+=float(incr)/(channel->GetRange()/2.0f-1.0f) ;
-			if (channel->IsCircular()) {
-				if (current>1.0) current-=1.0F ;
-				if (current<0.0) current+=1.0F ;						
-			} else {
-				if (current>1.0) current=1.0F ;
-				if (current<0.0) current=0.0F ;
-			}
-			channel->SetValue(current) ;
-			break ;
-		}
-		case MCT_SIGNED_BIT:
-		{
-			float current=channel->GetValue() ;
-			int incr=0 ;
-			if (data!=0)  {
-				if (data<0x41) {
-					incr=data ;
-				} else {
-					incr=0x40-data ;
-				} ;
-			} ;
-			current+=float(incr)/(channel->GetRange()/2.0f-1.0f) ;
-			if (channel->IsCircular()) {
-				if (current>1.0) current-=1.0F ;
-				if (current<0.0) current+=1.0F ;						
-			} else {
-				if (current>1.0) current=1.0F ;
-				if (current<0.0) current=0.0F ;
-			}
-			channel->SetValue(current) ;
-			break ;
-		}
-		case MCT_SIGNED_BIT_2:
-		{
-			float current=channel->GetValue() ;
-			int incr=0 ;
-			if (data!=0)  {
-				if (data<0x41) {
-					incr=-data ;
-				} else {
-					incr=data-0x40 ;
-				} ;
-			} ;
-			current+=float(incr)/(channel->GetRange()/2.0f-1.0f) ;
-			if (channel->IsCircular()) {
-				if (current>1.0) current-=1.0F ;
-				if (current<0.0) current+=1.0F ;						
-			} else {
-				if (current>1.0) current=1.0F ;
-				if (current<0.0) current=0.0F ;
-			}
-			channel->SetValue(current) ;
-			break ;
-		}
-		case MCT_BIN_OFFSET:
-		{
-			float current=channel->GetValue() ;
-			int incr=0 ;
-			if (data!=0)  {
-				if (data<0x41) {
-					incr=data-0x40 ;
-				} else {
-					incr=data-0x40 ;
-				} ;
-			} ;
-			current+=float(incr)/(channel->GetRange()/2.0f-1.0f) ;
-			if (channel->IsCircular()) {
-				if (current>1.0) current-=1.0F ;
-				if (current<0.0) current+=1.0F ;						
-			} else {
-				if (current>1.0) current=1.0F ;
-				if (current<0.0) current=0.0F ;
-			}
-			channel->SetValue(current) ;
-			break ;
-		}
-	} ;
-	channel->Trigger() ;
-} ;
+            channel->SetValue((data>0)?float(data+1)/(channel->GetRange()/2.0f):0);
+            break;
+        case MCT_HIRES:
+        {
+            float channelValue=channel->GetValue();
+            int current=(channelValue==0)?0:int(channelValue*16384-1);
+            int hi=current/128;
+            int low=current-hi*128;
+            if (hiNibble) {
+                hi=data;
+            } else {
+                low=data;
+            }
+            current=hi*128+low;
+            channel->SetValue((current==0)?0:(current+1)/16384.0f);
+            }
+            break;
+        case MCT_2_COMP:
+        {
+            float current=channel->GetValue();
+            int incr=0;
+            if (data!=0)  {
+                if (data<0x41) {
+                    incr=data;
+                } else {
+                    incr=data-0x80;
+                }
+            }
+            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
+            if (channel->IsCircular()) {
+                if (current>1.0) current-=1.0F;
+                if (current<0.0) current+=1.0F;                        
+            } else {
+                if (current>1.0) current=1.0F;
+                if (current<0.0) current=0.0F;
+            }
+            channel->SetValue(current);
+            break ;
+        }
+        case MCT_SIGNED_BIT:
+        {
+            float current=channel->GetValue();
+            int incr=0;
+            if (data!=0)  {
+                if (data<0x41) {
+                    incr=data;
+                } else {
+                    incr=0x40-data;
+                }
+            }
+            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
+            if (channel->IsCircular()) {
+                if (current>1.0) current-=1.0F;
+                if (current<0.0) current+=1.0F;                        
+            } else {
+                if (current>1.0) current=1.0F;
+                if (current<0.0) current=0.0F;
+            }
+            channel->SetValue(current);
+            break;
+        }
+        case MCT_SIGNED_BIT_2:
+        {
+            float current=channel->GetValue();
+            int incr=0;
+            if (data!=0)  {
+                if (data<0x41) {
+                    incr=-data;
+                } else {
+                    incr=data-0x40;
+                }
+            }
+            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
+            if (channel->IsCircular()) {
+                if (current>1.0) current-=1.0F;
+                if (current<0.0) current+=1.0F;                        
+            } else {
+                if (current>1.0) current=1.0F;
+                if (current<0.0) current=0.0F;
+            }
+            channel->SetValue(current);
+            break;
+        }
+        case MCT_BIN_OFFSET:
+        {
+            float current=channel->GetValue();
+            int incr=0;
+            if (data!=0)  {
+                if (data<0x41) {
+                    incr=data-0x40;
+                } else {
+                    incr=data-0x40;
+                } ;
+            } ;
+            current+=float(incr)/(channel->GetRange()/2.0f-1.0f);
+            if (channel->IsCircular()) {
+                if (current>1.0) current-=1.0F;
+                if (current<0.0) current+=1.0F;                        
+            } else {
+                if (current>1.0) current=1.0F;
+                if (current<0.0) current=0.0F;
+            }
+            channel->SetValue(current);
+            break;
+        }
+    }
+    channel->Trigger();
+}
 
 void MidiInDevice::treatNoteOff(MidiChannel *channel) {
-	if (!channel->IsToggle()) {
-		channel->SetValue(0.0F) ;
-	}
-	channel->Trigger() ;
-} ;
+    if (!channel->IsToggle()) {
+        channel->SetValue(0.0F);
+    }
+    channel->Trigger();
+}
 
 void MidiInDevice::treatNoteOn(MidiChannel *channel,int data) {
-	if (data==0) { // Actually a note off
-		if (!channel->IsToggle()) {
-			channel->SetValue(0.0F) ;
-		}
-	} else {
-		if (!channel->IsToggle()) {
-			channel->SetValue(1.0F) ;
-		} else {
-			float current=channel->GetValue() ;
-			channel->SetValue((current>0.5)?0.0f:1.0f) ;
-		} ;
-	}
-	channel->Trigger() ;
-} ;
+    if (data==0) { // Actually a note off
+        if (!channel->IsToggle()) {
+            channel->SetValue(0.0F);
+        }
+    } else {
+        if (!channel->IsToggle()) {
+            channel->SetValue(1.0F);
+        } else {
+            float current=channel->GetValue();
+            channel->SetValue((current>0.5)?0.0f:1.0f);
+        };
+    }
+    channel->Trigger();
+}

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -149,8 +149,17 @@ void MidiInDevice::Trigger(Time time) {
 void MidiInDevice::treatChannelEvent(MidiMessage &event) {
 
     int midiChannel = event.status_ & 0x0F;
-
     bool isMidiClockEvent = (event.status_ == 0xF8);
+    
+    // Midi clock events happen alot so handle them first to make the codepath shorter
+    if (isMidiClockEvent) {
+        // Todo: SL implement midi clock
+        return;
+    }
+    
+    if (!isMidiClockEvent) {
+        Trace::Debug("midi in:%X:%X:%X",event.status_, event.data1_, event.data2_);
+    }
 
     switch (event.GetType())
     {
@@ -255,25 +264,31 @@ void MidiInDevice::treatChannelEvent(MidiMessage &event) {
                 channel->Trigger();
             }
         }
-        case MidiMessage::MIDI_START:
-        {
-            Trace::Log("EVENT","midi:start");
-            onMidiStart();
-            break;
-        }
-        case MidiMessage::MIDI_CONTINUE:
-        {
-            Trace::Log("EVENT","midi:continue");
-            onMidiContinue();
-            break;
-        }
-        case MidiMessage::MIDI_STOP:
-        {
-            Trace::Log("EVENT","midi:stop");
-            onMidiStop();
-            break;
-        }
-        case 0xF0: // Midi clock
+        case MidiMessage::MIDI_MIDI_CLOCK: // Midi clock
+            // MIDI_START = 0xFA,
+            // MIDI_CONTINUE = 0xFB,
+            // MIDI_STOP = 0xFC,
+            switch (event.status_)
+            {
+                case 0xFA:
+                {
+                    Trace::Log("EVENT","midi:start");
+                    onMidiStart();
+                    break;
+                }
+                case 0xFB:
+                {
+                    Trace::Log("EVENT","midi:continue");
+                    onMidiContinue();
+                    break;
+                }
+                case 0xFC:
+                {
+                    Trace::Log("EVENT","midi:stop");
+                    onMidiStop();
+                    break;
+                }
+            }
             break;
         default:
             break;

--- a/sources/Services/Midi/MidiInDevice.cpp
+++ b/sources/Services/Midi/MidiInDevice.cpp
@@ -68,6 +68,12 @@ void MidiInDevice::onMidiStart() {
 	NotifyObservers() ;
 } ;
 
+void MidiInDevice::onMidiContinue() {
+	MidiSyncData data(MSM_CONTINUE) ;
+	SetChanged() ;
+	NotifyObservers() ;
+} ;
+
 void MidiInDevice::onMidiStop() {
 	MidiSyncData data(MSM_STOP) ;
 	SetChanged() ;
@@ -238,6 +244,24 @@ void MidiInDevice::treatChannelEvent(MidiMessage &event) {
         channel->Trigger();
 			} ;
 		}
+        case MidiMessage::MIDI_START:
+        {
+            Trace::Log("EVENT","midi:start") ;
+            onMidiStart();
+            break;
+        }
+        case MidiMessage::MIDI_CONTINUE:
+        {
+            Trace::Log("EVENT","midi:continue") ;
+            onMidiContinue();
+            break;
+        }
+        case MidiMessage::MIDI_STOP:
+        {
+            Trace::Log("EVENT","midi:stop") ;
+            onMidiStop();
+            break;
+        }
 		case 0xF0: // Midi clock
 			break ;
 		default:

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -1,68 +1,68 @@
 #ifndef _MIDIIN_DEVICE_H_
 #define _MIDIIN_DEVICE_H_
 
-#include "Services/Controllers/ControllerSource.h"
-#include "Foundation/T_Stack.h"
 #include "Foundation/Observable.h"
+#include "Foundation/T_Stack.h"
+#include "Services/Controllers/ControllerSource.h"
 #include "MidiMessage.h"
 #include "MidiChannel.h"
 
 enum MidiSyncMessage {
-	MSM_START,
+    MSM_START,
     MSM_CONTINUE,
-	MSM_STOP,
-	MSM_TEMPOTICK
-} ;
+    MSM_STOP,
+    MSM_TEMPOTICK
+};
 
 struct MidiSyncData:public I_ObservableData {
-	MidiSyncMessage message_ ;
-	MidiSyncData(MidiSyncMessage msg):message_(msg) {} ;
-} ;
+    MidiSyncMessage message_;
+    MidiSyncData(MidiSyncMessage msg):message_(msg) {};
+};
 
 class MidiInDevice: public Observable,public ControllerSource,protected T_Stack<MidiMessage> {
 public:
-	MidiInDevice(const char *name) ;
-	virtual ~MidiInDevice() ;
-	bool Init() ;
-	void Close() ;
-	bool Start() ;
-	void Stop() ;
+    MidiInDevice(const char *name);
+    virtual ~MidiInDevice();
+    bool Init();
+    void Close();
+    bool Start();
+    void Stop();
 
-	virtual Channel *GetChannel(const char *name) ;
-	virtual bool IsRunning() ;
-	virtual void Trigger(Time time) ;
+    virtual Channel *GetChannel(const char *name);
+    virtual bool IsRunning();
+    virtual void Trigger(Time time);
 
 protected:
-	// Driver specific initialisation
-	virtual bool initDriver()=0 ;
-	virtual void closeDriver()=0 ;
-	virtual bool startDriver()=0 ;
-	virtual void stopDriver()=0 ;
+    // Driver specific initialisation
+    virtual bool initDriver()=0;
+    virtual void closeDriver()=0;
+    virtual bool startDriver()=0;
+    virtual void stopDriver()=0;
 
-	void treatChannelEvent(MidiMessage &event) ;
-	void treatCC(MidiChannel *channel,int,bool hiNibble=false) ;
-	void treatNoteOff(MidiChannel *channel) ;
-	void treatNoteOn(MidiChannel *channel,int value) ;
-	bool isRunning_ ;
+    void treatChannelEvent(MidiMessage &event);
+    void treatCC(MidiChannel *channel,int,bool hiNibble=false);
+    void treatNoteOff(MidiChannel *channel);
+    void treatNoteOn(MidiChannel *channel,int value);
+    bool isRunning_;
 
-	// Callbacks from driver
+    // Callbacks from driver
 
-	void onDriverMessage(MidiMessage &event) ;
-	void onMidiTempoTick() ;
-	void onMidiStart() ;
-    void onMidiContinue() ;
-	void onMidiStop() ;
-	// void queueEvent(MidiEvent &event) ;
+    void onDriverMessage(MidiMessage &event);
+    void onMidiTempoTick();
+    void onMidiStart();
+    void onMidiContinue();
+    void onMidiStop();
+    // void queueEvent(MidiEvent &event);
 
 private:
   static bool dumpEvents_;
-	// MIDI Channel dependant channels
-	MidiChannel *ccChannel_[16][128] ;		// Control Change
-	MidiChannel *noteChannel_[16][128] ;	// Note on / note off
-	MidiChannel *atChannel_[16][128] ;		// After touch
-	MidiChannel *pbChannel_[16] ;			// Pitch bend
-	MidiChannel *catChannel_[16] ;			// Channel after touch
-	MidiChannel *pcChannel_[16] ;			// Program change
-} ;
+    // MIDI Channel dependant channels
+    MidiChannel *ccChannel_[16][128];       // Control Change
+    MidiChannel *noteChannel_[16][128];     // Note on / note off
+    MidiChannel *atChannel_[16][128];       // After touch
+    MidiChannel *pbChannel_[16];            // Pitch bend
+    MidiChannel *catChannel_[16];           // Channel after touch
+    MidiChannel *pcChannel_[16];            // Program change
+};
 
-#endif
+#endif // _MIDIIN_DEVICE_H_

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -3,24 +3,21 @@
 
 #include "Foundation/Observable.h"
 #include "Foundation/T_Stack.h"
-#include "Services/Controllers/ControllerSource.h"
-#include "MidiMessage.h"
 #include "MidiChannel.h"
+#include "MidiMessage.h"
+#include "Services/Controllers/ControllerSource.h"
 
-enum MidiSyncMessage {
-    MSM_START,
-    MSM_CONTINUE,
-    MSM_STOP,
-    MSM_TEMPOTICK
-};
+enum MidiSyncMessage { MSM_START, MSM_CONTINUE, MSM_STOP, MSM_TEMPOTICK };
 
-struct MidiSyncData:public I_ObservableData {
+struct MidiSyncData : public I_ObservableData {
     MidiSyncMessage message_;
-    MidiSyncData(MidiSyncMessage msg):message_(msg) {};
+    MidiSyncData(MidiSyncMessage msg) : message_(msg) {};
 };
 
-class MidiInDevice: public Observable,public ControllerSource,protected T_Stack<MidiMessage> {
-public:
+class MidiInDevice : public Observable,
+                     public ControllerSource,
+                     protected T_Stack<MidiMessage> {
+  public:
     MidiInDevice(const char *name);
     virtual ~MidiInDevice();
     bool Init();
@@ -32,17 +29,17 @@ public:
     virtual bool IsRunning();
     virtual void Trigger(Time time);
 
-protected:
+  protected:
     // Driver specific initialisation
-    virtual bool initDriver()=0;
-    virtual void closeDriver()=0;
-    virtual bool startDriver()=0;
-    virtual void stopDriver()=0;
+    virtual bool initDriver() = 0;
+    virtual void closeDriver() = 0;
+    virtual bool startDriver() = 0;
+    virtual void stopDriver() = 0;
 
     void treatChannelEvent(MidiMessage &event);
-    void treatCC(MidiChannel *channel,int,bool hiNibble=false);
+    void treatCC(MidiChannel *channel, int, bool hiNibble = false);
     void treatNoteOff(MidiChannel *channel);
-    void treatNoteOn(MidiChannel *channel,int value);
+    void treatNoteOn(MidiChannel *channel, int value);
     bool isRunning_;
 
     // Callbacks from driver
@@ -54,15 +51,15 @@ protected:
     void onMidiStop();
     // void queueEvent(MidiEvent &event);
 
-private:
-  static bool dumpEvents_;
+  private:
+    static bool dumpEvents_;
     // MIDI Channel dependant channels
-    MidiChannel *ccChannel_[16][128];       // Control Change
-    MidiChannel *noteChannel_[16][128];     // Note on / note off
-    MidiChannel *atChannel_[16][128];       // After touch
-    MidiChannel *pbChannel_[16];            // Pitch bend
-    MidiChannel *catChannel_[16];           // Channel after touch
-    MidiChannel *pcChannel_[16];            // Program change
+    MidiChannel *ccChannel_[16][128];   // Control Change
+    MidiChannel *noteChannel_[16][128]; // Note on / note off
+    MidiChannel *atChannel_[16][128];   // After touch
+    MidiChannel *pbChannel_[16];        // Pitch bend
+    MidiChannel *catChannel_[16];       // Channel after touch
+    MidiChannel *pcChannel_[16];        // Program change
 };
 
 #endif // _MIDIIN_DEVICE_H_

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -9,6 +9,7 @@
 
 enum MidiSyncMessage {
 	MSM_START,
+    MSM_CONTINUE,
 	MSM_STOP,
 	MSM_TEMPOTICK
 } ;
@@ -49,6 +50,7 @@ protected:
 	void onDriverMessage(MidiMessage &event) ;
 	void onMidiTempoTick() ;
 	void onMidiStart() ;
+    void onMidiContinue() ;
 	void onMidiStop() ;
 	// void queueEvent(MidiEvent &event) ;
 

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -47,11 +47,11 @@ protected:
 	// Callbacks from driver
 
 	void onDriverMessage(MidiMessage &event) ;
-/*	void onMidiTempoTick() ;
+	void onMidiTempoTick() ;
 	void onMidiStart() ;
 	void onMidiStop() ;
-	void queueEvent(MidiEvent &event) ;
-*/
+	// void queueEvent(MidiEvent &event) ;
+
 private:
   static bool dumpEvents_;
 	// MIDI Channel dependant channels

--- a/sources/Services/Midi/MidiMessage.h
+++ b/sources/Services/Midi/MidiMessage.h
@@ -16,6 +16,9 @@ struct MidiMessage:public I_ObservableData
     MIDI_CHANNEL_AFTERTOUCH = 0xD0,
     MIDI_PITCH_BEND = 0xE0,
     MIDI_MIDI_CLOCK = 0xF0,
+    MIDI_START = 0xFA,
+    MIDI_CONTINUE = 0xFB,
+    MIDI_STOP = 0xFC,
   };
   
  static const unsigned char UNUSED_BYTE = 255;

--- a/sources/Services/Midi/MidiMessage.h
+++ b/sources/Services/Midi/MidiMessage.h
@@ -16,9 +16,6 @@ struct MidiMessage:public I_ObservableData
     MIDI_CHANNEL_AFTERTOUCH = 0xD0,
     MIDI_PITCH_BEND = 0xE0,
     MIDI_MIDI_CLOCK = 0xF0,
-    MIDI_START = 0xFA,
-    MIDI_CONTINUE = 0xFB,
-    MIDI_STOP = 0xFC,
   };
   
  static const unsigned char UNUSED_BYTE = 255;

--- a/sources/Services/Midi/MidiService.cpp
+++ b/sources/Services/Midi/MidiService.cpp
@@ -1,10 +1,9 @@
 #include "MidiService.h"
-#include "Application/Player/SyncMaster.h"
-#include "System/Console/Trace.h"
-#include "System/Timer/Timer.h"
 #include "Application/Model/Config.h"
+#include "Application/Player/SyncMaster.h"
 #include "Services/Audio/AudioDriver.h"
 #include "System/Console/Trace.h"
+#include "System/Timer/Timer.h"
 
 #ifdef SendMessage
 #undef SendMessage

--- a/sources/Services/Midi/MidiService.cpp
+++ b/sources/Services/Midi/MidiService.cpp
@@ -11,190 +11,189 @@
 #endif
 	
 MidiService::MidiService():
-	T_SimpleList<MidiOutDevice>(true),
-  inList_(true),
-	device_(0),
-	sendSync_(true)
+    T_SimpleList<MidiOutDevice>(true),
+    inList_(true),
+    device_(0),
+    sendSync_(true)
 {
-	for (int i=0;i<MIDI_MAX_BUFFERS;i++) {
-		queues_[i]=new T_SimpleList<MidiMessage>(true);
-	}
+    for (int i=0;i<MIDI_MAX_BUFFERS;i++) {
+        queues_[i]=new T_SimpleList<MidiMessage>(true);
+    }
 
-	const char *delay = Config::GetInstance()->GetValue("MIDIDELAY");
-	midiDelay_ = delay?atoi(delay):1;
+    const char *delay = Config::GetInstance()->GetValue("MIDIDELAY");
+    midiDelay_ = delay?atoi(delay):1;
 
-	const char *sendSync = Config::GetInstance()->GetValue("MIDISENDSYNC");
-	if (sendSync) {
-		sendSync_ = (strcmp(sendSync,"YES")==0);
-	}
-};
+    const char *sendSync = Config::GetInstance()->GetValue("MIDISENDSYNC");
+    if (sendSync) {
+        sendSync_ = (strcmp(sendSync,"YES")==0);
+    }
+}
 
 MidiService::~MidiService() {
-	Close();
-};
+    Close();
+}
 
 bool MidiService::Init() {
-	Empty();
-  inList_.Empty();
-	buildDriverList();
-	// Add a merger for the input
-	merger_=new MidiInMerger();
-	IteratorPtr<MidiInDevice>it(inList_.GetIterator());
-	for (it->Begin();!it->IsDone();it->Next()) {
-		MidiInDevice &current=it->CurrentItem();
-		merger_->Insert(current);
-	}
+    Empty();
+    inList_.Empty();
+    buildDriverList();
+    // Add a merger for the input
+    merger_=new MidiInMerger();
+    IteratorPtr<MidiInDevice>it(inList_.GetIterator());
+    for (it->Begin();!it->IsDone();it->Next()) {
+        MidiInDevice &current=it->CurrentItem();
+        merger_->Insert(current);
+    }
 
-	return true;
-};
+    return true;
+}
 
 void MidiService::Close() {
-	Stop();
-};
+    Stop();
+}
 
 I_Iterator<MidiInDevice> *MidiService::GetInIterator() {
-	return inList_.GetIterator();
-};
+    return inList_.GetIterator();
+}
 
 void MidiService::SelectDevice(const std::string &name) {
-	deviceName_ = name;
-};
+    deviceName_ = name;
+}
 
 bool MidiService::Start() {
-	currentPlayQueue_ = 0;
-	currentOutQueue_ = 0;
-	return true;
-} ;
-
+    currentPlayQueue_ = 0;
+    currentOutQueue_ = 0;
+    return true;
+}
 
 void MidiService::Stop() {
-	stopDevice();
-} ;
+    stopDevice();
+}
 
 void MidiService::QueueMessage(MidiMessage &m) {
-	if (device_) {
+    if (device_) {
         SysMutexLocker locker(queueMutex_) ;
-		T_SimpleList<MidiMessage> *queue=queues_[currentPlayQueue_];
-		MidiMessage *ms=new MidiMessage(m.status_,m.data1_,m.data2_);
-		queue->Insert(ms);
-	}
-};
+        T_SimpleList<MidiMessage> *queue=queues_[currentPlayQueue_];
+        MidiMessage *ms=new MidiMessage(m.status_,m.data1_,m.data2_);
+        queue->Insert(ms);
+    }
+}
 
 void MidiService::Trigger() {
-	AdvancePlayQueue();
+    AdvancePlayQueue();
 
-	if (device_&&sendSync_) {
-		SyncMaster *sm=SyncMaster::GetInstance();
-		if (sm->MidiSlice()) {
-			MidiMessage msg;
-			msg.status_ = 0xF8;
-			QueueMessage(msg);
-		}
-	}
+    if (device_&&sendSync_) {
+        SyncMaster *sm=SyncMaster::GetInstance();
+        if (sm->MidiSlice()) {
+            MidiMessage msg;
+            msg.status_ = 0xF8;
+            QueueMessage(msg);
+        }
+    }
 }
 
 void MidiService::AdvancePlayQueue() {
- 	currentPlayQueue_=(currentPlayQueue_+1)%MIDI_MAX_BUFFERS;
+    currentPlayQueue_=(currentPlayQueue_+1)%MIDI_MAX_BUFFERS;
     SysMutexLocker locker(queueMutex_) ;
-	T_SimpleList<MidiMessage> *queue=queues_[currentPlayQueue_];
-	queue->Empty();
+    T_SimpleList<MidiMessage> *queue=queues_[currentPlayQueue_];
+    queue->Empty();
 }
 
 void MidiService::Update(Observable &o,I_ObservableData *d) {
-  AudioDriver::Event *event=(AudioDriver::Event *)d;
-  if (event->type_ == AudioDriver::Event::ADET_DRIVERTICK) {
-    onAudioTick();
-  }
-};
+    AudioDriver::Event *event=(AudioDriver::Event *)d;
+    if (event->type_ == AudioDriver::Event::ADET_DRIVERTICK) {
+        onAudioTick();
+    }
+}
 
 void MidiService::onAudioTick() {
-	if (tickToFlush_>0) {
-		if (--tickToFlush_ ==0) {
-			flushOutQueue();
-		}
-	}
+    if (tickToFlush_>0) {
+        if (--tickToFlush_ ==0) {
+            flushOutQueue();
+        }
+    }
 }
 
 void MidiService::Flush() {
-	tickToFlush_ = midiDelay_;
-	if (tickToFlush_ == 0) {
-		flushOutQueue();
-	}
-};
+    tickToFlush_ = midiDelay_;
+    if (tickToFlush_ == 0) {
+        flushOutQueue();
+    }
+}
 
 void MidiService::flushOutQueue() {
-  // Move queue positions
-  currentOutQueue_ = (currentOutQueue_+1) % MIDI_MAX_BUFFERS;
-  SysMutexLocker locker(queueMutex_) ;
-	T_SimpleList<MidiMessage> *flushQueue=queues_[currentOutQueue_];
+    // Move queue positions
+    currentOutQueue_ = (currentOutQueue_+1) % MIDI_MAX_BUFFERS;
+    SysMutexLocker locker(queueMutex_) ;
+    T_SimpleList<MidiMessage> *flushQueue=queues_[currentOutQueue_];
   
-	if (device_) {
-    // Send whatever is on the out queue
-		device_->SendQueue(*flushQueue);
-	}
-	flushQueue->Empty();
+    if (device_) {
+        // Send whatever is on the out queue
+        device_->SendQueue(*flushQueue);
+    }
+    flushQueue->Empty();
 }
 
 /*
  * starts midi device
  */
 void MidiService::startDevice() {
-	IteratorPtr<MidiOutDevice>it(GetIterator()) ;
+    IteratorPtr<MidiOutDevice>it(GetIterator()) ;
 
-	for (it->Begin(); !it->IsDone(); it->Next()) {
-		MidiOutDevice &current = it->CurrentItem();
-		if (!strcmp(deviceName_.c_str(), current.GetName())) {
-			if (current.Init()) {
-				if (current.Start()) {
-					Trace::Log("MidiService", "midi device %s started", deviceName_.c_str());
-					device_ = &current;
-				} else {
-					Trace::Log("MidiService", "midi device %s failed to start", deviceName_.c_str());
-					current.Close();
+    for (it->Begin(); !it->IsDone(); it->Next()) {
+        MidiOutDevice &current = it->CurrentItem();
+        if (!strcmp(deviceName_.c_str(), current.GetName())) {
+            if (current.Init()) {
+                if (current.Start()) {
+                    Trace::Log("MidiService", "midi device %s started", deviceName_.c_str());
+                    device_ = &current;
+                } else {
+                    Trace::Log("MidiService", "midi device %s failed to start", deviceName_.c_str());
+                    current.Close();
 				}
-			}
-			break;
-		}
-	}
-};
+            }
+            break;
+        }
+    }
+}
 
 /*
  * closes midi device
  */
 void MidiService::stopDevice() {
-	if (device_) {
-		device_->Stop() ;
-		device_->Close() ;
-	}
-	device_=0 ;
-} ;
+    if (device_) {
+        device_->Stop() ;
+        device_->Close() ;
+    }
+    device_=0 ;
+}
 
 /*
  * starts midi device when playback starts
  */
 void MidiService::OnPlayerStart() {
-	if (deviceName_.size()!=0) {
-		stopDevice();
-		startDevice();
-		deviceName_="";
-	} else {
-    startDevice();
-  }
+    if (deviceName_.size()!=0) {
+        stopDevice();
+        startDevice();
+        deviceName_="";
+    } else {
+        startDevice();
+    }
 
-	if (sendSync_) {
-		MidiMessage msg ;
-		msg.status_=0xFA ;
-		QueueMessage(msg) ;
-	}
-};
+    if (sendSync_) {
+        MidiMessage msg ;
+        msg.status_=0xFA ;
+        QueueMessage(msg) ;
+    }
+}
 
 /*
  * queues midi stop message when player stops
  */
 void MidiService::OnPlayerStop() {
-	if (sendSync_) {
-		MidiMessage msg ;
-		msg.status_=0xFC ;
-		QueueMessage(msg) ;
-	}
-};
+    if (sendSync_) {
+        MidiMessage msg ;
+        msg.status_=0xFC ;
+        QueueMessage(msg) ;
+    }
+}

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -2,92 +2,88 @@
 #ifndef _MIDI_SERVICE_H_
 #define _MIDI_SERVICE_H_
 
-#include <string>
 #include "Foundation/Observable.h"
 #include "Foundation/T_Factory.h"
-#include "System/Process/SysMutex.h"
-#include "System/Timer/Timer.h"
 #include "MidiInDevice.h"
 #include "MidiInMerger.h"
 #include "MidiOutDevice.h"
-
+#include "System/Process/SysMutex.h"
+#include "System/Timer/Timer.h"
+#include <string>
 
 #define MIDI_MAX_BUFFERS 20
 
-class MidiService
-:public T_Factory<MidiService>
-,public T_SimpleList<MidiOutDevice>
-,public I_Observer
-{
+class MidiService : public T_Factory<MidiService>,
+                    public T_SimpleList<MidiOutDevice>,
+                    public I_Observer {
 
-public:
-    MidiService() ;
-    virtual ~MidiService() ;
+  public:
+    MidiService();
+    virtual ~MidiService();
 
-    bool Init() ;
-    void Close() ;
-    bool Start() ;
-    void Stop() ;
+    bool Init();
+    void Close();
+    bool Start();
+    void Stop();
 
-    void SelectDevice(const std::string &name) ;
+    void SelectDevice(const std::string &name);
 
-    I_Iterator<MidiInDevice> *GetInIterator() ;
+    I_Iterator<MidiInDevice> *GetInIterator();
 
     //! player notification
 
-    void OnPlayerStart() ;
-    void OnPlayerStop() ;
+    void OnPlayerStart();
+    void OnPlayerStop();
 
     //! Queues a MidiMessage to the current time chunk
 
-    void QueueMessage(MidiMessage &) ;
+    void QueueMessage(MidiMessage &);
 
     //! Time chunk trigger
 
-    void Trigger() ;
+    void Trigger();
     void AdvancePlayQueue();
 
     //! Flush current queue to the output
 
-    void Flush() ;
-  
+    void Flush();
 
-protected:
+  protected:
+    T_SimpleList<MidiInDevice> inList_;
 
-    T_SimpleList<MidiInDevice> inList_ ;
-
-    virtual void Update(Observable &o,I_ObservableData *d) ;
+    virtual void Update(Observable &o, I_ObservableData *d);
     void onAudioTick();
 
     //! start the selected midi device
 
-    void startInDevice() ;
-    void startOutDevice() ;
+    void startInDevice();
+    void startOutDevice();
 
     //! stop the selected midi device
 
-    void stopInDevice() ;
-    void stopOutDevice() ;
+    void stopInDevice();
+    void stopOutDevice();
 
     //! build the list of available drivers
 
-    virtual void buildDriverList()=0 ;
+    virtual void buildDriverList() = 0;
 
-private:
+  private:
     void flushOutQueue();
-private:
-    std::string deviceName_ ;
-    MidiInDevice *inDevice_ ;
-    MidiOutDevice *outDevice_ ;
 
-    T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS] ;
-    int currentPlayQueue_ ;
-    int currentOutQueue_ ;
+  private:
+    std::string deviceName_;
+    MidiInDevice *inDevice_;
+    MidiOutDevice *outDevice_;
 
-    MidiInMerger *merger_ ;
-    int midiDelay_ ;
-    int tickToFlush_ ;
-    bool sendSync_ ;
-    SysMutex queueMutex_ ;    
-} ;
+    T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS];
+    int currentPlayQueue_;
+    int currentOutQueue_;
+
+    MidiInMerger *merger_;
+    int midiDelay_;
+    int tickToFlush_;
+    bool sendSync_;
+    SysMutex queueMutex_;
+};
 #endif

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -61,10 +61,12 @@ protected:
 
     //! start the selected midi device
 
+    void startInDevice() ;
     void startOutDevice() ;
 
     //! stop the selected midi device
 
+    void stopInDevice() ;
     void stopOutDevice() ;
 
     //! build the list of available drivers
@@ -75,6 +77,7 @@ private:
     void flushOutQueue();
 private:
     std::string deviceName_ ;
+    MidiInDevice *inDevice_ ;
     MidiOutDevice *outDevice_ ;
 
     T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS] ;

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -3,14 +3,14 @@
 #define _MIDI_SERVICE_H_
 
 #include <string>
-#include "Foundation/T_Factory.h"
 #include "Foundation/Observable.h"
-#include "System/Timer/Timer.h"
+#include "Foundation/T_Factory.h"
 #include "System/Process/SysMutex.h"
-#include "MidiOutDevice.h"
-#include "MidiInDevice.h"
+#include "System/Timer/Timer.h"
 #include "MidiInDevice.h"
 #include "MidiInMerger.h"
+#include "MidiOutDevice.h"
+
 
 #define MIDI_MAX_BUFFERS 20
 

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -61,11 +61,11 @@ protected:
 
     //! start the selected midi device
 
-    void startDevice() ;
+    void startOutDevice() ;
 
     //! stop the selected midi device
 
-    void stopDevice() ;
+    void stopOutDevice() ;
 
     //! build the list of available drivers
 
@@ -75,7 +75,7 @@ private:
     void flushOutQueue();
 private:
     std::string deviceName_ ;
-    MidiOutDevice *device_ ;
+    MidiOutDevice *outDevice_ ;
 
     T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS] ;
     int currentPlayQueue_ ;

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -21,70 +21,70 @@ class MidiService
 {
 
 public:
-	MidiService() ;
-	virtual ~MidiService() ;
+    MidiService() ;
+    virtual ~MidiService() ;
 
-	bool Init() ;
-	void Close() ;
-	bool Start() ;
-	void Stop() ;
+    bool Init() ;
+    void Close() ;
+    bool Start() ;
+    void Stop() ;
 
-	void SelectDevice(const std::string &name) ;
+    void SelectDevice(const std::string &name) ;
 
-	I_Iterator<MidiInDevice> *GetInIterator() ;
+    I_Iterator<MidiInDevice> *GetInIterator() ;
 
-	//! player notification
+    //! player notification
 
-	void OnPlayerStart() ;
-	void OnPlayerStop() ;
+    void OnPlayerStart() ;
+    void OnPlayerStop() ;
 
-	//! Queues a MidiMessage to the current time chunk
+    //! Queues a MidiMessage to the current time chunk
 
-	void QueueMessage(MidiMessage &) ;
+    void QueueMessage(MidiMessage &) ;
 
-	//! Time chunk trigger
+    //! Time chunk trigger
 
-	void Trigger() ;
-  void AdvancePlayQueue();
+    void Trigger() ;
+    void AdvancePlayQueue();
 
-	//! Flush current queue to the output
+    //! Flush current queue to the output
 
-	void Flush() ;
+    void Flush() ;
   
 
 protected:
 
-	T_SimpleList<MidiInDevice> inList_ ;
+    T_SimpleList<MidiInDevice> inList_ ;
 
-  virtual void Update(Observable &o,I_ObservableData *d) ;
-  void onAudioTick();
+    virtual void Update(Observable &o,I_ObservableData *d) ;
+    void onAudioTick();
 
-	//! start the selected midi device
+    //! start the selected midi device
 
-	void startDevice() ;
+    void startDevice() ;
 
-	//! stop the selected midi device
+    //! stop the selected midi device
 
-	void stopDevice() ;
+    void stopDevice() ;
 
-	//! build the list of available drivers
+    //! build the list of available drivers
 
-	virtual void buildDriverList()=0 ;
+    virtual void buildDriverList()=0 ;
 
 private:
-  void flushOutQueue();
+    void flushOutQueue();
 private:
-	std::string deviceName_ ;
-	MidiOutDevice *device_ ;
+    std::string deviceName_ ;
+    MidiOutDevice *device_ ;
 
-	T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS] ;
-	int currentPlayQueue_ ;
-	int currentOutQueue_ ;
+    T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS] ;
+    int currentPlayQueue_ ;
+    int currentOutQueue_ ;
 
-	MidiInMerger *merger_ ;
-	int midiDelay_ ;
-  int tickToFlush_ ;
-	bool sendSync_ ;
+    MidiInMerger *merger_ ;
+    int midiDelay_ ;
+    int tickToFlush_ ;
+    bool sendSync_ ;
     SysMutex queueMutex_ ;    
 } ;
 #endif


### PR DESCRIPTION
* Rather then only using midi input from the config, it now also follows the midi input in the project settings.
* lgpt now starts and stops with, start and stop events from Midi In.
* General cleanup on parts of the code that were touched.

Todo in Pt 2:
* Disable midi transport via a config file option.
* Use midi in tempo events for sync and setting tempo
* Fix continue behavior (Currently it restarts)