### PR TITLE
Add color options for Border Play and Mute

### DIFF
--- a/docs/LittlePiggyTrackerConf.md
+++ b/docs/LittlePiggyTrackerConf.md
@@ -103,18 +103,24 @@ LittleGPTracker uses 4 colours to do all the drawing. If you want, you can redef
 -   `BACKGROUND`: color of the background
     
 -   `FOREGROUND`: color of the foreground
+
+-   `BORDER`: color of the border in the start screen / dialogs
     
 -   `HICOLOR1`: row count in song screen
     
 -   `HICOLOR2`: inverted color
 
--   `CURSORCOLOR` :  Cursor color
+-   `CURSORCOLOR`:  Cursor color
 
--   `ROWCOLOR1` :    Row count color 1
+-   `PLAYCOLOR`: play indicator color
 
--   `ROWCOLOR2` :    Row count color 2
+-   `MUTECOLOR`: mute indicator color
 
--   `ALTROWNUMBER` : How many rows before alternating between ROWCOLOR1/2
+-   `ROWCOLOR1`: row count color 1
+
+-   `ROWCOLOR2`: row count color 2
+
+-   `ALTROWNUMBER`: how many rows before alternating between ROWCOLOR1/2
 
 -   `MAJORBEAT`: color of "--" at row 00,04,08,0c in phrase screen
     

--- a/docs/wiki/config_xml.md
+++ b/docs/wiki/config_xml.md
@@ -60,12 +60,15 @@ LittleGPTracker uses 6 colours to do all the drawing. If you want, you can redef
 
 -   `BACKGROUND`: color of the background
 -   `FOREGROUND`: color of the foreground
+-   `BORDER`: color of the border in the start screen / dialogs
 -   `HICOLOR1`: row count in song screen
 -   `HICOLOR2`: cursor color
+-   `PLAYCOLOR`: play indicator color
+-   `MUTECOLOR`: mute indicator color
 -   `SONGVIEW_FE`: color of the chain "FE" in song screen
 -   `SONGVIEW_00`: color of the chain "00" in song screen
--   `ROWCOLOR1`: Row count color 1
--   `ROWCOLOR2`: Row count color 2
+-   `ROWCOLOR1`: row count color 1
+-   `ROWCOLOR2`: row count color 2
 -   `ALTROWNUMBER`: How many rows for each rowcolor
 -   `MAJORBEAT`: color of "--" at row 00,04,08,0c in phrase screen
 
@@ -73,16 +76,19 @@ All colors are defined by a set of hexadecimal triplet for RGB. Here's an exampl
 
 ```
 <CONFIG>
-	<BACKGROUND value="505444" />
-	<FOREGROUND value="FFFFFF" /> <!-- text and cursor in cursor -->
-	<HICOLOR1 value="F41B38" /> <!-- Highlight color 1 -->
-	<HICOLOR2 value="FF0000" /> <!-- Highlight color 2 -->
-	<SONGVIEW_FE value="A55B8F" /> <!-- color of the chain "FE" in song screen-->
-	<SONGVIEW_00 value="853B6F" /> <!-- color of the chain "00" in song screen-->
-	<CURSORCOLOR value = "FF00DD"/> <!--Cursor color-->
-	<ROWCOLOR1 value = "BA28F9"/> <!--Row count color 1 -->
-	<ROWCOLOR2 value = "FF00FF"/> <!--Row count color 2-->
-	<ALTROWNUMBER value = "4"/>      <!--How many rows of each ROWCOLOR-->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
 </CONFIG>
 ```
 
@@ -106,15 +112,15 @@ To connect the button to a keyboard key, it's pretty easy: simply put the key na
 
 ```
 <CONFIG>
-	<KEY_A value="f" />
-	<KEY_B value="d" />
-	<KEY_LEFT value="j" />
-	<KEY_RIGHT value="l" />
-	<KEY_UP value="i" />
-	<KEY_DOWN value="k" />
-	<KEY_LSHOULDER value="a" />
-	<KEY_RSHOULDER value=";" />
-	<KEY_START value="space" />
+    <KEY_A value="f" />
+    <KEY_B value="d" />
+    <KEY_LEFT value="j" />
+    <KEY_RIGHT value="l" />
+    <KEY_UP value="i" />
+    <KEY_DOWN value="k" />
+    <KEY_LSHOULDER value="a" />
+    <KEY_RSHOULDER value=";" />
+    <KEY_START value="space" />
 </CONFIG>
 ```
 
@@ -128,7 +134,7 @@ Here's an example that maps the start button to the X on PSP:
 
 ```
 <CONFIG>
-	<KEY_START value="but:0:11" />
+    <KEY_START value="but:0:11" />
 </CONFIG>
 ```
 
@@ -143,7 +149,7 @@ You can select one of the three fonts provided with this application.
 Set the value of FONTTYPE in the config file to '0', '1', or '2' to apply the corresponding font.
 ```
 <CONFIG>
-	<FONTTYPE value='1' />
+    <FONTTYPE value='1' />
 </CONFIG>
 ```
 
@@ -152,7 +158,7 @@ To use a custom font, set the value of the FONTTYPE key to 'CUSTOM'
 
 ```
 <CONFIG>
-	<FONTTYPE value='CUSTOM' />
+    <FONTTYPE value='CUSTOM' />
 </CONFIG>
 ```
 and place the custom_font.xml file in the same directory as the application.
@@ -179,8 +185,8 @@ You can tweak the timing used to repeat the arrows keys and other.
 
 ```
 <CONFIG>
-	<KEYDELAY value="185"/>
-	<KEYREPEAT value="40"/>
+    <KEYDELAY value="185"/>
+    <KEYREPEAT value="40"/>
 </CONFIG>
 ```
 ## Path
@@ -192,8 +198,8 @@ You can tweak two different path:
 
 ```
 <CONFIG>
-	<ROOTFOLDER value="c:/files/tracks/"/>
-	<SAMPLELIB value="root:"/>
+    <ROOTFOLDER value="c:/files/tracks/"/>
+    <SAMPLELIB value="root:"/>
 </CONFIG>
 ```
 
@@ -203,7 +209,7 @@ Additionally to playing the song, LittleGPTracker can be used to render the audi
 
 ```
 <CONFIG>
-<RENDER value='FILERT'/>
+    <RENDER value='FILERT'/>
 </CONFIG>
 ```
 
@@ -213,7 +219,7 @@ This setting is for GP2X and Dingoo only. It is used to set the volume of the ha
 
 ```
 <CONFIG>
-<VOLUME value='60'/>
+    <VOLUME value='60'/>
 </CONFIG>
 ```
 
@@ -228,8 +234,8 @@ These settings are used to control various options of the audio configuration. T
 
 ```
 <CONFIG>
-<AUDIODRIVER value='Real'/>
-<AUDIOBUFFERSIZE value='512'/>
+    <AUDIODRIVER value='Real'/>
+    <AUDIOBUFFERSIZE value='512'/>
 </CONFIG>
 ```
 
@@ -239,7 +245,7 @@ This setting is also W32 only. It can be use to delay the output of midi by a ce
 
 ```
 <CONFIG>
-  <MIDIDELAY value='1'/>
+    <MIDIDELAY value='1'/>
 </CONFIG>
 ```
 
@@ -251,6 +257,6 @@ Get piggy dumping a log on the terminal or to a .log file, useful for debugging 
 
 ```
 <CONFIG>
-  <DUMPEVENT value='YES'/>
+    <DUMPEVENT value='YES'/>
 </CONFIG>
 ```

--- a/projects/resources/CHIP/config.xml
+++ b/projects/resources/CHIP/config.xml
@@ -23,14 +23,19 @@
     <!-- Uncomment to render
     <RENDER value="FILE" />
     -->
-<!-- Default colors below -->
-    <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-    <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-    <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-    <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-    <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
-    <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-    <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-    <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
-    <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
+    <!-- Default colors below -->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
+    <FONTTYPE     value = '0' />      <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 </CONFIG>

--- a/projects/resources/DEB/config.xml
+++ b/projects/resources/DEB/config.xml
@@ -15,16 +15,19 @@
 	<KEY_START value="key:0:return" />
 -->
 <!-- Default colors below -->
-    <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-    <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-    <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-    <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-    <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
-    <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
-    <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
-    <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-    <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-    <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
-    <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
+    <FONTTYPE     value = '0' />      <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 
 </CONFIG>

--- a/projects/resources/MACOS/config.xml
+++ b/projects/resources/MACOS/config.xml
@@ -14,18 +14,20 @@
 
 	<KEY_START value="space" />
 
-<!-- Default colors below -->
-    <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-    <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-    <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-    <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-    <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
-    <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
-    <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
-    <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-    <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-    <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
-    <MAJORBEAT    value = "BA28F9"/> <!--major beat color -->
-    <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
+    <!-- Default colors below -->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
+    <FONTTYPE     value = '0' />      <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 
 </CONFIG>

--- a/projects/resources/MIYOO/config.xml
+++ b/projects/resources/MIYOO/config.xml
@@ -4,27 +4,31 @@ create folders for your tracks and samples on the
 root of your sd card.
 -->
 <CONFIG>
-  <ROOTFOLDER value="/mnt/SDCARD/Tracks"/>
-  <SAMPLELIB value="/mnt/SDCARD/Samples"/>
-  <!-- uncomment to dump events to stdout -->
-  <!--
-  <DUMPEVENT value="YES"/>
-  -->
-  <!-- uncomment to render -->
-  <!--
-  <RENDER value="FILE"/>
-  -->
-<!-- Default colors below -->
-  <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-  <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-  <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-  <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-  <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
-  <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
-  <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
-  <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-  <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-  <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
-  <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
+    <ROOTFOLDER value="/mnt/SDCARD/Tracks"/>
+    <SAMPLELIB value="/mnt/SDCARD/Samples"/>
+    <!-- uncomment to dump events to stdout -->
+    <!--
+    <DUMPEVENT value="YES"/>
+    -->
+    <!-- uncomment to render -->
+    <!--
+    <RENDER value="FILE"/>
+    -->
+    <!-- Default colors below -->
+    <!-- Default colors below -->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
+    <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 
 </CONFIG>

--- a/projects/resources/PSP/config.xml
+++ b/projects/resources/PSP/config.xml
@@ -3,16 +3,19 @@
 	<SCREENMULT value="1"/> <!-- Does nothing on PSP -->
 
 <!-- Default colors below -->
-    <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-    <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-    <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-    <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-    <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
+    <BACKGROUND   value = "1D0A1F" /> <!--Background color-->
+    <FOREGROUND   value = "F5EBFF" /> <!--Text color-->
+    <BORDER       value = "FF00DD" /> <!--Dialog border color-->    
+    <HICOLOR1     value = "B750D1" /> <!--Highlight color 1-->
+    <HICOLOR2     value = "DB33DB" /> <!--Highlight color 2-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Play indicator color-->
+    <MUTECOLOR    value = "F5EBFF" /> <!--Mute indicator color-->    
     <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
     <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
-    <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-    <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-    <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
-    <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows before alternating-->
+    <FONTTYPE     value = '0' />      <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 
 </CONFIG>

--- a/projects/resources/X64/config.xml
+++ b/projects/resources/X64/config.xml
@@ -1,30 +1,35 @@
 <CONFIG>
-	<DUMPEVENT value="YES"/>
-	<SCREENMULT value="2"/> <!-- increase screen size -->
-<!--
-	<KEY_A value="key:0:x"/>
-	<KEY_B value="key:0:z"/>
-	<KEY_LSHOULDER value="key:0:a" />
-	<KEY_RSHOULDER value="key:0:s" />
-
-	<KEY_UP value="key:0:up" />
-	<KEY_DOWN value="key:0:down" />
-	<KEY_LEFT value="key:0:left" />
-	<KEY_RIGHT value="key:0:right" />
-
-	<KEY_START value="key:0:return" />
--->
-<!-- Default colors below -->
-    <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
-    <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
-    <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
-    <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
-    <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
-    <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
-    <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
-    <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->
-    <ROWCOLOR2    value = "FF00FF"/> <!--Row count color 2-->
-    <ALTROWNUMBER value = "4"/>      <!--How many rows before alternating-->
+    <DUMPEVENT value="YES"/>
+    <SCREENMULT value="2"/> <!-- increase screen size -->
+    <!--
+    <KEY_A value="key:0:x"/>
+    <KEY_B value="key:0:z"/>
+    <KEY_LSHOULDER value="key:0:a" />
+    <KEY_RSHOULDER value="key:0:s" />
+    
+    <KEY_UP value="key:0:up" />
+    <KEY_DOWN value="key:0:down" />
+    <KEY_LEFT value="key:0:left" />
+    <KEY_RIGHT value="key:0:right" />
+    
+    <KEY_START value="key:0:return" />
+    -->
+    <!-- Default colors below -->
+    <!-- Default colors below -->
+    <BACKGROUND   value = "505444" />
+    <FOREGROUND   value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <BORDER       value = "FF00DD" /> <!--Dialog Border-->
+    <HICOLOR1     value = "F41B38" /> <!-- Highlight color 1 -->
+    <HICOLOR2     value = "FF0000" /> <!-- Highlight color 2 -->
+    <SONGVIEW_FE  value = "A55B8F" /> <!-- Color of the chain "FE" in song screen-->
+    <SONGVIEW_00  value = "853B6F" /> <!-- Color of the chain "00" in song screen-->
+    <CURSORCOLOR  value = "FF00DD" /> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD" /> <!--Cursor color-->
+    <MUTECOLOR    value = "FFFFFF" /> <!-- Text and cursor in cursor -->
+    <ROWCOLOR1    value = "BA28F9" /> <!--Row count color 1 -->
+    <ROWCOLOR2    value = "FF00FF" /> <!--Row count color 2-->
+    <ALTROWNUMBER value = "4"/>       <!--How many rows of each ROWCOLOR-->
+    <ALTROWNUMBER value = "4"/>
     <FONTTYPE     value = '0' />     <!-- '0':original '1':digital '2':monster 'CUSTOM': load custom_font.xml-->
 
 </CONFIG>

--- a/projects/resources/X86/config.xml
+++ b/projects/resources/X86/config.xml
@@ -17,9 +17,12 @@
 <!-- Default colors below -->
     <BACKGROUND   value = "1D0A1F"/> <!--Background color-->
     <FOREGROUND   value = "F5EBFF"/> <!--Text color-->
+    <BORDER       value = "FF00DD"/> <!--Border color-->    
     <HICOLOR1     value = "B750D1"/> <!--Highlight color 1-->
     <HICOLOR2     value = "DB33DB"/> <!--Highlight color 2-->
     <CURSORCOLOR  value = "FF00DD"/> <!--Cursor color-->
+    <PLAYCOLOR    value = "FF00DD"/> <!--Cursor color-->
+    <MUTECOLOR    value = "F5EBFF"/> <!--Text color-->
     <SONGVIEW_FE  value = "A55B8F" /> <!--Alt chain color1-->
     <SONGVIEW_00  value = "853B6F" /> <!--Alt chain color2-->
     <ROWCOLOR1    value = "BA28F9"/> <!--Row count color 1 -->

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -20,12 +20,15 @@ AppWindow *instance=0 ;
 
 GUIColor AppWindow::backgroundColor_(0x1D,0x0A,0x1F); 
 GUIColor AppWindow::normalColor_    (0xF5,0xEB,0xFF);
+GUIColor AppWindow::borderColor_    (0xFF,0x00,0x8C);
 GUIColor AppWindow::songviewfeColor_(0xA5,0x5B,0x8F);
 GUIColor AppWindow::songview00Color_(0x85,0x3B,0x6F);
 GUIColor AppWindow::highlightColor_ (0xB7,0x50,0xD1);
 GUIColor AppWindow::highlight2Color_(0xDB,0x33,0xDB);
 GUIColor AppWindow::consoleColor_   (0x00,0xFF,0x00);
 GUIColor AppWindow::cursorColor_    (0xFF,0x00,0x8C);
+GUIColor AppWindow::playColor_      (0xFF,0x00,0x8C);
+GUIColor AppWindow::muteColor_      (0xF5,0xEB,0xFF);
 GUIColor AppWindow::rownumberColor_ (0xBA,0x28,0xF9);
 GUIColor AppWindow::rownumber2Color_(0xFF,0x00,0xFF);
 GUIColor AppWindow::majorbeatColor_ (0xBA,0x28,0xF9);
@@ -98,16 +101,19 @@ AppWindow::AppWindow(I_GUIWindowImp &imp):GUIWindow(imp)  {
 	// Init midi services
 	MidiService::GetInstance()->Init() ;
 
-    defineColor("BACKGROUND",backgroundColor_) ;
-    defineColor("FOREGROUND",normalColor_) ;
-	defineColor("SONGVIEW_FE",songviewfeColor_) ;
-	defineColor("SONGVIEW_00",songview00Color_) ;
-    defineColor("HICOLOR1",highlightColor_) ;
-    defineColor("HICOLOR2",highlight2Color_) ;
-    defineColor("CURSORCOLOR",cursorColor_) ;
+    defineColor("BACKGROUND",backgroundColor_);
+    defineColor("FOREGROUND",normalColor_);
+    defineColor("BORDER",borderColor_);
+    defineColor("SONGVIEW_FE",songviewfeColor_);
+    defineColor("SONGVIEW_00",songview00Color_);
+    defineColor("HICOLOR1",highlightColor_);
+    defineColor("HICOLOR2",highlight2Color_);
+    defineColor("CURSORCOLOR",cursorColor_);
+    defineColor("PLAYCOLOR",playColor_);
+    defineColor("MUTECOLOR",muteColor_);
     defineColor("ROWCOLOR1",rownumberColor_);
     defineColor("ROWCOLOR2",rownumber2Color_);
-	defineColor("MAJORBEAT",majorbeatColor_);
+    defineColor("MAJORBEAT",majorbeatColor_);
 	
 
 	GUIWindow::Clear(backgroundColor_) ;
@@ -220,55 +226,64 @@ void AppWindow::Flush() {
 	unsigned char *previous=_preScreen ;
 	unsigned char *currentProp=_charScreenProp ;
 	unsigned char *previousProp=_preScreenProp ;
-	for (int y=0;y<30;y++) {
-		for (int x=0;x<40;x++) {
+    for (int y=0;y<30;y++) {
+        for (int x=0;x<40;x++) {
 #ifndef _LGPT_NO_SCREEN_CACHE_
-			if ((*current!=*previous)||(*currentProp!=*previousProp)) {
+            if ((*current!=*previous)||(*currentProp!=*previousProp)) {
 #endif
-				props.invert_=(*currentProp&PROP_INVERT)!=0 ;
-				if (((*currentProp)&0x7F)!=color) {
-					color=(ColorDefinition)((*currentProp)&0x7F) ;
-					GUIColor gcolor=normalColor_ ;
-					switch (color) {
-						case CD_BACKGROUND:
-							gcolor=backgroundColor_ ;
-							break ;
-						case CD_NORMAL:
-							break ;
+                props.invert_=(*currentProp&PROP_INVERT)!=0 ;
+                if (((*currentProp)&0x7F)!=color) {
+                    color=(ColorDefinition)((*currentProp)&0x7F) ;
+                    GUIColor gcolor=normalColor_;
+                    switch (color) {
+                        case CD_BACKGROUND:
+                            gcolor=backgroundColor_;
+                            break;
+                        case CD_NORMAL:
+                            break;
+                        case CD_BORDER:
+                            gcolor=borderColor_;
+                            break;
 						case CD_HILITE1:
-							gcolor=highlightColor_ ;
-							break ;
-						case CD_HILITE2:
-							gcolor=highlight2Color_ ;
-							break ;
-						case CD_CONSOLE:
-							gcolor=consoleColor_ ;
-							break ;
-						case CD_CURSOR:
-							gcolor=cursorColor_ ;
-							break ;
+                            gcolor=highlightColor_;
+                            break;
+                        case CD_HILITE2:
+                            gcolor=highlight2Color_;
+                            break;
+                        case CD_CONSOLE:
+                            gcolor=consoleColor_;
+                            break;
+                        case CD_CURSOR:
+                            gcolor=cursorColor_;
+                            break;
+                        case CD_PLAY:
+                            gcolor = playColor_;
+                            break;
+                        case CD_MUTE:
+                            gcolor = muteColor_;
+                            break;
 						case CD_SONGVIEWFE:
-							gcolor = songviewfeColor_;
+                            gcolor = songviewfeColor_;
+                            break;
+                        case CD_SONGVIEW00:
+                            gcolor = songview00Color_;
+                            break;
+                        case CD_ROW:
+                            gcolor = rownumberColor_;
+                            break;
+                        case CD_ROW2:
+                            gcolor = rownumber2Color_;
+                            break;
+                        case CD_MAJORBEAT:
+                            gcolor = majorbeatColor_;
+                            break;
+                        default:
+                            NAssert(0);
 							break;
-						case CD_SONGVIEW00:
-							gcolor = songview00Color_;
-							break;
-						case CD_ROW:
-							gcolor = rownumberColor_;
-							break;
-						case CD_ROW2:
-							gcolor = rownumber2Color_;
-							break;
-						case CD_MAJORBEAT:
-							gcolor = majorbeatColor_;
-							break;
-						default:
-							NAssert(0) ;
-							break ;
-					}
-					GUIWindow::SetColor(gcolor) ;
-				}
-				GUIWindow::DrawChar(*current,pos,props) ;
+                    }
+                    GUIWindow::SetColor(gcolor);
+                }
+				GUIWindow::DrawChar(*current,pos,props);
 				count++ ;
 #ifndef _LGPT_NO_SCREEN_CACHE_
 			}

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -1,192 +1,184 @@
 #include "AppWindow.h"
-#include "UIFramework/Interfaces/I_GUIWindowFactory.h"
-#include "System/Console/Trace.h"
-#include "Player/Player.h"
-#include "Foundation/Variables/WatchedVariable.h"
-#include "Views/UIController.h"
-#include "Application/Persistency/PersistencyService.h" 
-#include "Application/Instruments/SamplePool.h"
-#include "Application/Player/TablePlayback.h"
-#include "Services/Midi/MidiService.h"
-#include "Application/Views/ModalDialogs/MessageBox.h"
-#include "Application/Commands/EventDispatcher.h"
 #include "Application/Commands/ApplicationCommandDispatcher.h"
-#include "Application/Views/ModalDialogs/SelectProjectDialog.h"
-#include "Application/Utils/char.h"
+#include "Application/Commands/EventDispatcher.h"
+#include "Application/Instruments/SamplePool.h"
 #include "Application/Mixer/MixerService.h"
+#include "Application/Persistency/PersistencyService.h"
+#include "Application/Player/TablePlayback.h"
+#include "Application/Utils/char.h"
+#include "Application/Views/ModalDialogs/MessageBox.h"
+#include "Application/Views/ModalDialogs/SelectProjectDialog.h"
+#include "Foundation/Variables/WatchedVariable.h"
+#include "Player/Player.h"
+#include "Services/Midi/MidiService.h"
+#include "System/Console/Trace.h"
+#include "UIFramework/Interfaces/I_GUIWindowFactory.h"
+#include "Views/UIController.h"
 #include <string.h>
 
-AppWindow *instance=0 ;
+AppWindow *instance = 0;
 
-GUIColor AppWindow::backgroundColor_(0x1D,0x0A,0x1F); 
-GUIColor AppWindow::normalColor_    (0xF5,0xEB,0xFF);
-GUIColor AppWindow::borderColor_    (0xFF,0x00,0x8C);
-GUIColor AppWindow::songviewfeColor_(0xA5,0x5B,0x8F);
-GUIColor AppWindow::songview00Color_(0x85,0x3B,0x6F);
-GUIColor AppWindow::highlightColor_ (0xB7,0x50,0xD1);
-GUIColor AppWindow::highlight2Color_(0xDB,0x33,0xDB);
-GUIColor AppWindow::consoleColor_   (0x00,0xFF,0x00);
-GUIColor AppWindow::cursorColor_    (0xFF,0x00,0x8C);
-GUIColor AppWindow::playColor_      (0xFF,0x00,0x8C);
-GUIColor AppWindow::muteColor_      (0xF5,0xEB,0xFF);
-GUIColor AppWindow::rownumberColor_ (0xBA,0x28,0xF9);
-GUIColor AppWindow::rownumber2Color_(0xFF,0x00,0xFF);
-GUIColor AppWindow::majorbeatColor_ (0xBA,0x28,0xF9);
+GUIColor AppWindow::backgroundColor_(0x1D, 0x0A, 0x1F);
+GUIColor AppWindow::normalColor_(0xF5, 0xEB, 0xFF);
+GUIColor AppWindow::borderColor_(0xFF, 0x00, 0x8C);
+GUIColor AppWindow::songviewfeColor_(0xA5, 0x5B, 0x8F);
+GUIColor AppWindow::songview00Color_(0x85, 0x3B, 0x6F);
+GUIColor AppWindow::highlightColor_(0xB7, 0x50, 0xD1);
+GUIColor AppWindow::highlight2Color_(0xDB, 0x33, 0xDB);
+GUIColor AppWindow::consoleColor_(0x00, 0xFF, 0x00);
+GUIColor AppWindow::cursorColor_(0xFF, 0x00, 0x8C);
+GUIColor AppWindow::playColor_(0xFF, 0x00, 0x8C);
+GUIColor AppWindow::muteColor_(0xF5, 0xEB, 0xFF);
+GUIColor AppWindow::rownumberColor_(0xBA, 0x28, 0xF9);
+GUIColor AppWindow::rownumber2Color_(0xFF, 0x00, 0xFF);
+GUIColor AppWindow::majorbeatColor_(0xBA, 0x28, 0xF9);
 
+int AppWindow::charWidth_ = 8;
+int AppWindow::charHeight_ = 8;
 
+// #define _FORCE_SDL_EVENT_
 
-int AppWindow::charWidth_=8;
-int AppWindow::charHeight_=8 ;
+static void ProjectSelectCallback(View &v, ModalView &dialog) {
 
-//#define _FORCE_SDL_EVENT_
+    SelectProjectDialog &spd = (SelectProjectDialog &)dialog;
+    if (dialog.GetReturnCode() > 0) {
+        Path selected = spd.GetSelection();
+        instance->LoadProject(selected.GetPath().c_str());
+    } else {
+        System::GetInstance()->PostQuitMessage();
+    }
+};
 
-static void ProjectSelectCallback(View &v,ModalView &dialog) {
+void AppWindow::defineColor(const char *colorName, GUIColor &color) {
 
-	SelectProjectDialog &spd=(SelectProjectDialog &)dialog ;
-	if (dialog.GetReturnCode()>0) {
-		Path selected=spd.GetSelection() ;
-		instance->LoadProject(selected.GetPath().c_str()) ;
-	} else {
-		System::GetInstance()->PostQuitMessage() ;
-	}
-} ;
-
-void AppWindow::defineColor(const char *colorName,GUIColor &color) {
-
-       Config *config=Config::GetInstance() ;
-       const char *value=config->GetValue(colorName) ;
-       if (value) {
-          unsigned char r ;
-          char2hex(value,&r) ;
-          unsigned char g ;
-          char2hex(value+2,&g) ;
-          unsigned char b ;
-          char2hex(value+4,&b) ;
-          color=GUIColor(r,g,b) ;
-       }
+    Config *config = Config::GetInstance();
+    const char *value = config->GetValue(colorName);
+    if (value) {
+        unsigned char r;
+        char2hex(value, &r);
+        unsigned char g;
+        char2hex(value + 2, &g);
+        unsigned char b;
+        char2hex(value + 4, &b);
+        color = GUIColor(r, g, b);
+    }
 }
 
+AppWindow::AppWindow(I_GUIWindowImp &imp) : GUIWindow(imp) {
 
-AppWindow::AppWindow(I_GUIWindowImp &imp):GUIWindow(imp)  {
+    instance = this;
 
-	instance=this ;
+    // Init all members
 
-	// Init all members
+    _statusLine[0] = 0;
 
-	_statusLine[0]=0 ;
+    _currentView = 0;
+    _viewData = 0;
+    _songView = 0;
+    _chainView = 0;
+    _phraseView = 0;
+    _projectView = 0;
+    _instrumentView = 0;
+    _tableView = 0;
+    _nullView = 0;
+    _mixerView = 0;
+    _grooveView = 0;
+    _closeProject = 0;
+    _loadAfterSaveAsProject = 0;
+    _lastA = 0;
+    _lastB = 0;
+    _mask = 0;
+    colorIndex_ = CD_NORMAL;
 
-	_currentView=0 ;
-	_viewData=0 ;
-	_songView=0 ;
-	_chainView=0 ;
-	_phraseView=0 ;
-	_projectView=0 ;
-	_instrumentView=0 ;
-	_tableView=0 ;
-	_nullView=0 ;
-	_mixerView=0 ;
-	_grooveView=0 ;
-	_closeProject=0 ;
-	_loadAfterSaveAsProject=0 ;
-	_lastA=0 ;
-	_lastB=0 ;
-	_mask=0 ;
-	colorIndex_=CD_NORMAL;
+    EventDispatcher *ed = EventDispatcher::GetInstance();
+    ed->SetWindow(this);
 
-	EventDispatcher *ed=EventDispatcher::GetInstance() ;
-	ed->SetWindow(this) ;
+    Status::Install(this);
 
-	Status::Install(this) ;
+    // Init midi services
+    MidiService::GetInstance()->Init();
 
-	// Init midi services
-	MidiService::GetInstance()->Init() ;
+    defineColor("BACKGROUND", backgroundColor_);
+    defineColor("FOREGROUND", normalColor_);
+    defineColor("BORDER", borderColor_);
+    defineColor("SONGVIEW_FE", songviewfeColor_);
+    defineColor("SONGVIEW_00", songview00Color_);
+    defineColor("HICOLOR1", highlightColor_);
+    defineColor("HICOLOR2", highlight2Color_);
+    defineColor("CURSORCOLOR", cursorColor_);
+    defineColor("PLAYCOLOR", playColor_);
+    defineColor("MUTECOLOR", muteColor_);
+    defineColor("ROWCOLOR1", rownumberColor_);
+    defineColor("ROWCOLOR2", rownumber2Color_);
+    defineColor("MAJORBEAT", majorbeatColor_);
 
-    defineColor("BACKGROUND",backgroundColor_);
-    defineColor("FOREGROUND",normalColor_);
-    defineColor("BORDER",borderColor_);
-    defineColor("SONGVIEW_FE",songviewfeColor_);
-    defineColor("SONGVIEW_00",songview00Color_);
-    defineColor("HICOLOR1",highlightColor_);
-    defineColor("HICOLOR2",highlight2Color_);
-    defineColor("CURSORCOLOR",cursorColor_);
-    defineColor("PLAYCOLOR",playColor_);
-    defineColor("MUTECOLOR",muteColor_);
-    defineColor("ROWCOLOR1",rownumberColor_);
-    defineColor("ROWCOLOR2",rownumber2Color_);
-    defineColor("MAJORBEAT",majorbeatColor_);
-	
+    GUIWindow::Clear(backgroundColor_);
 
-	GUIWindow::Clear(backgroundColor_) ;
-	
-	_nullView=new NullView((*this),0) ;
-	_currentView=_nullView ;
-	_nullView->SetDirty(true) ;
+    _nullView = new NullView((*this), 0);
+    _currentView = _nullView;
+    _nullView->SetDirty(true);
 
-	SelectProjectDialog *spd=new SelectProjectDialog(*_currentView) ;
-	_currentView->DoModal(spd,ProjectSelectCallback) ;
+    SelectProjectDialog *spd = new SelectProjectDialog(*_currentView);
+    _currentView->DoModal(spd, ProjectSelectCallback);
 
+    memset(_charScreen, ' ', 1200);
+    memset(_preScreen, ' ', 1200);
+    memset(_charScreenProp, 0, 1200);
+    memset(_preScreenProp, 0, 1200);
 
-	memset(_charScreen,' ',1200) ;
-	memset(_preScreen,' ',1200) ;
-	memset(_charScreenProp,0,1200) ;
-	memset(_preScreenProp,0,1200) ;
+    Redraw();
+};
 
-	Redraw() ;
-} ;
+AppWindow::~AppWindow() { MidiService::GetInstance()->Close(); }
 
-AppWindow::~AppWindow() {
-	MidiService::GetInstance()->Close() ;
-}
+void AppWindow::DrawString(const char *string, GUIPoint &pos,
+                           GUITextProperties &props, bool force) {
 
+    // we know we don't have mode than 40 chars
 
-void AppWindow::DrawString(const char *string,GUIPoint &pos,GUITextProperties &props,bool force) {
+    char buffer[41];
+    int len = strlen(string);
+    int offset = (pos._x < 0) ? -pos._x / 8 : 0;
+    len -= offset;
+    int available = 40 - ((pos._x < 0) ? 0 : pos._x);
+    len = MIN(len, available);
+    memcpy(buffer, string + offset, len);
+    buffer[len] = 0;
 
-// we know we don't have mode than 40 chars
-
-	char buffer[41] ;
-	int len=strlen(string) ;
-	int offset=(pos._x<0)?-pos._x/8:0 ;
-	len-=offset ;
-	int available=40-((pos._x<0)?0:pos._x) ;
-	len=MIN(len,available) ;
-	memcpy(buffer,string+offset,len) ;
-	buffer[len]=0 ;
-
-	NAssert((pos._x<40)&&(pos._y<30)) ;
-	int index=pos._x+40*pos._y ;
-	memcpy(_charScreen+index,buffer,len) ;
-	unsigned char prop=colorIndex_+(props.invert_?PROP_INVERT:0) ;
-	memset(_charScreenProp+index,prop,len) ;
-} ;
+    NAssert((pos._x < 40) && (pos._y < 30));
+    int index = pos._x + 40 * pos._y;
+    memcpy(_charScreen + index, buffer, len);
+    unsigned char prop = colorIndex_ + (props.invert_ ? PROP_INVERT : 0);
+    memset(_charScreenProp + index, prop, len);
+};
 
 void AppWindow::Clear(bool all) {
-	memset(_charScreen,' ',1200) ;
-	memset(_charScreenProp,0,1200) ;
-	if (all)  {
-		memset(_preScreen,' ',1200) ;
-		memset(_preScreenProp,0,1200) ;
-	} ;
-} ;
+    memset(_charScreen, ' ', 1200);
+    memset(_charScreenProp, 0, 1200);
+    if (all) {
+        memset(_preScreen, ' ', 1200);
+        memset(_preScreenProp, 0, 1200);
+    };
+};
 
 void AppWindow::ClearRect(GUIRect &r) {
 
-	int x=r.Left() ;
-	int y=r.Top() ;
-	int w=r.Width();
-	int h=r.Height() ;
+    int x = r.Left();
+    int y = r.Top();
+    int w = r.Width();
+    int h = r.Height();
 
-	unsigned char *st=_charScreen+x+(40*y) ;
-	unsigned char *pr=_charScreenProp+x+(40*y) ;
-	for (int i=0;i<h;i++) {
-		for (int j=0;j<w;j++) {
-			*st++=' ' ;
-			*pr++=0 ;
-		}
-		st+=(40-w) ;
-		pr+=(40-w) ;
-	}
-} ;
-
+    unsigned char *st = _charScreen + x + (40 * y);
+    unsigned char *pr = _charScreenProp + x + (40 * y);
+    for (int i = 0; i < h; i++) {
+        for (int j = 0; j < w; j++) {
+            *st++ = ' ';
+            *pr++ = 0;
+        }
+        st += (40 - w);
+        pr += (40 - w);
+    }
+};
 
 //
 // Redraws the screen and flush it.
@@ -194,13 +186,13 @@ void AppWindow::ClearRect(GUIRect &r) {
 
 void AppWindow::Redraw() {
 
-	SysMutexLocker locker(drawMutex_) ;
-	
-	if (_currentView) {
-		_currentView->Redraw() ;
-		Invalidate() ;
-	}
-} ;
+    SysMutexLocker locker(drawMutex_);
+
+    if (_currentView) {
+        _currentView->Redraw();
+        Invalidate();
+    }
+};
 
 //
 // Flush current screen to display
@@ -208,434 +200,427 @@ void AppWindow::Redraw() {
 
 void AppWindow::Flush() {
 
-	SysMutexLocker locker(drawMutex_) ;
+    SysMutexLocker locker(drawMutex_);
 
-	Lock() ;
-	long flushStart=System::GetInstance()->GetClock() ;
+    Lock();
+    long flushStart = System::GetInstance()->GetClock();
 
-	GUITextProperties props ;
-	GUIPoint pos ;
+    GUITextProperties props;
+    GUIPoint pos;
 
-	ColorDefinition color=(ColorDefinition)-1 ;
-	pos._x=0 ;
-	pos._y=0 ;
+    ColorDefinition color = (ColorDefinition)-1;
+    pos._x = 0;
+    pos._y = 0;
 
-	int count=0 ;
+    int count = 0;
 
-	unsigned char *current=_charScreen ;
-	unsigned char *previous=_preScreen ;
-	unsigned char *currentProp=_charScreenProp ;
-	unsigned char *previousProp=_preScreenProp ;
-    for (int y=0;y<30;y++) {
-        for (int x=0;x<40;x++) {
+    unsigned char *current = _charScreen;
+    unsigned char *previous = _preScreen;
+    unsigned char *currentProp = _charScreenProp;
+    unsigned char *previousProp = _preScreenProp;
+    for (int y = 0; y < 30; y++) {
+        for (int x = 0; x < 40; x++) {
 #ifndef _LGPT_NO_SCREEN_CACHE_
-            if ((*current!=*previous)||(*currentProp!=*previousProp)) {
+            if ((*current != *previous) || (*currentProp != *previousProp)) {
 #endif
-                props.invert_=(*currentProp&PROP_INVERT)!=0 ;
-                if (((*currentProp)&0x7F)!=color) {
-                    color=(ColorDefinition)((*currentProp)&0x7F) ;
-                    GUIColor gcolor=normalColor_;
+                props.invert_ = (*currentProp & PROP_INVERT) != 0;
+                if (((*currentProp) & 0x7F) != color) {
+                    color = (ColorDefinition)((*currentProp) & 0x7F);
+                    GUIColor gcolor = normalColor_;
                     switch (color) {
-                        case CD_BACKGROUND:
-                            gcolor=backgroundColor_;
-                            break;
-                        case CD_NORMAL:
-                            break;
-                        case CD_BORDER:
-                            gcolor=borderColor_;
-                            break;
-						case CD_HILITE1:
-                            gcolor=highlightColor_;
-                            break;
-                        case CD_HILITE2:
-                            gcolor=highlight2Color_;
-                            break;
-                        case CD_CONSOLE:
-                            gcolor=consoleColor_;
-                            break;
-                        case CD_CURSOR:
-                            gcolor=cursorColor_;
-                            break;
-                        case CD_PLAY:
-                            gcolor = playColor_;
-                            break;
-                        case CD_MUTE:
-                            gcolor = muteColor_;
-                            break;
-						case CD_SONGVIEWFE:
-                            gcolor = songviewfeColor_;
-                            break;
-                        case CD_SONGVIEW00:
-                            gcolor = songview00Color_;
-                            break;
-                        case CD_ROW:
-                            gcolor = rownumberColor_;
-                            break;
-                        case CD_ROW2:
-                            gcolor = rownumber2Color_;
-                            break;
-                        case CD_MAJORBEAT:
-                            gcolor = majorbeatColor_;
-                            break;
-                        default:
-                            NAssert(0);
-							break;
+                    case CD_BACKGROUND:
+                        gcolor = backgroundColor_;
+                        break;
+                    case CD_NORMAL:
+                        break;
+                    case CD_BORDER:
+                        gcolor = borderColor_;
+                        break;
+                    case CD_HILITE1:
+                        gcolor = highlightColor_;
+                        break;
+                    case CD_HILITE2:
+                        gcolor = highlight2Color_;
+                        break;
+                    case CD_CONSOLE:
+                        gcolor = consoleColor_;
+                        break;
+                    case CD_CURSOR:
+                        gcolor = cursorColor_;
+                        break;
+                    case CD_PLAY:
+                        gcolor = playColor_;
+                        break;
+                    case CD_MUTE:
+                        gcolor = muteColor_;
+                        break;
+                    case CD_SONGVIEWFE:
+                        gcolor = songviewfeColor_;
+                        break;
+                    case CD_SONGVIEW00:
+                        gcolor = songview00Color_;
+                        break;
+                    case CD_ROW:
+                        gcolor = rownumberColor_;
+                        break;
+                    case CD_ROW2:
+                        gcolor = rownumber2Color_;
+                        break;
+                    case CD_MAJORBEAT:
+                        gcolor = majorbeatColor_;
+                        break;
+                    default:
+                        NAssert(0);
+                        break;
                     }
                     GUIWindow::SetColor(gcolor);
                 }
-				GUIWindow::DrawChar(*current,pos,props);
-				count++ ;
+                GUIWindow::DrawChar(*current, pos, props);
+                count++;
 #ifndef _LGPT_NO_SCREEN_CACHE_
-			}
+            }
 #endif
-			current++ ;
-			previous++ ;
-			currentProp++ ;
-			previousProp++ ;
-			pos._x+=AppWindow::charWidth_ ;
-		}		
-		pos._y+=AppWindow::charHeight_ ;
-		pos._x=0 ;
-	}
-	long flushEnd=System::GetInstance()->GetClock() ;
-  GUIWindow::Flush() ;
-	Unlock() ;
-	memcpy(_preScreen,_charScreen,1200) ;
-	memcpy(_preScreenProp,_charScreenProp,1200) ;
+            current++;
+            previous++;
+            currentProp++;
+            previousProp++;
+            pos._x += AppWindow::charWidth_;
+        }
+        pos._y += AppWindow::charHeight_;
+        pos._x = 0;
+    }
+    long flushEnd = System::GetInstance()->GetClock();
+    GUIWindow::Flush();
+    Unlock();
+    memcpy(_preScreen, _charScreen, 1200);
+    memcpy(_preScreenProp, _charScreenProp, 1200);
+};
 
-} ;
+void AppWindow::LoadProject(const Path &p) {
+    Trace::Log("LoadProject", "%s\n", p.GetPath().c_str());
+    _root = p;
 
-void AppWindow::LoadProject(const Path &p)  {
-	Trace::Log("LoadProject","%s\n", p.GetPath().c_str());
-	_root=p ;
+    _closeProject = false;
+    _loadAfterSaveAsProject = false;
 
-	_closeProject=false ;
-	_loadAfterSaveAsProject=false;
+    PersistencyService *persist = PersistencyService::GetInstance();
 
-	PersistencyService *persist=PersistencyService::GetInstance() ;
+    TablePlayback::Reset();
 
-	TablePlayback::Reset() ;
+    Path::SetAlias("project", _root.GetPath().c_str());
+    Path::SetAlias("samples", "project:samples");
 
-	Path::SetAlias("project",_root.GetPath().c_str()) ;
-	Path::SetAlias("samples","project:samples") ;
-	
-	// Load the sample pool
-	
-	SamplePool *pool=SamplePool::GetInstance() ;
-	
-	pool->Load() ;
+    // Load the sample pool
 
-	Project *project=new Project() ;
+    SamplePool *pool = SamplePool::GetInstance();
 
-	bool succeeded=persist->Load() ;
-	if (!succeeded) {
-		project->GetInstrumentBank()->AssignDefaults() ;
-	} ;
+    pool->Load();
+
+    Project *project = new Project();
+
+    bool succeeded = persist->Load();
+    if (!succeeded) {
+        project->GetInstrumentBank()->AssignDefaults();
+    };
 
     // Project
 
-	WatchedVariable::Disable() ;
-	
-	project->GetInstrumentBank()->Init() ;
+    WatchedVariable::Disable();
 
-	WatchedVariable::Enable() ;
+    project->GetInstrumentBank()->Init();
 
-	ApplicationCommandDispatcher::GetInstance()->Init(project) ;
+    WatchedVariable::Enable();
 
-	// Create view data
-	
-	_viewData=new ViewData(project) ;
+    ApplicationCommandDispatcher::GetInstance()->Init(project);
 
-	// Create & observe the player
-	Player *player=Player::GetInstance() ;
-	bool playerOK=player->Init(project,_viewData) ;
-	player->AddObserver(*this) ;
+    // Create view data
 
-	// Create the controller
-	UIController *controller=UIController::GetInstance() ;
-	controller->Init(project,_viewData) ;
+    _viewData = new ViewData(project);
 
-	// Create & observe all views
-	_songView=new SongView((*this),_viewData,_root.GetName().c_str()) ;
-	_songView->AddObserver((*this)) ;
+    // Create & observe the player
+    Player *player = Player::GetInstance();
+    bool playerOK = player->Init(project, _viewData);
+    player->AddObserver(*this);
 
-  _chainView=new ChainView((*this),_viewData) ;
-	_chainView->AddObserver((*this)) ;
+    // Create the controller
+    UIController *controller = UIController::GetInstance();
+    controller->Init(project, _viewData);
 
-  _phraseView=new PhraseView((*this),_viewData) ;
-	_phraseView->AddObserver((*this)) ;
+    // Create & observe all views
+    _songView = new SongView((*this), _viewData, _root.GetName().c_str());
+    _songView->AddObserver((*this));
 
-  _projectView=new ProjectView((*this),_viewData) ;
-	_projectView->AddObserver((*this)) ;
+    _chainView = new ChainView((*this), _viewData);
+    _chainView->AddObserver((*this));
 
-  _instrumentView=new InstrumentView((*this),_viewData) ;
-	_instrumentView->AddObserver((*this)) ;
+    _phraseView = new PhraseView((*this), _viewData);
+    _phraseView->AddObserver((*this));
 
-  _tableView=new TableView((*this),_viewData) ;
-	_tableView->AddObserver((*this)) ;
+    _projectView = new ProjectView((*this), _viewData);
+    _projectView->AddObserver((*this));
 
-	_grooveView=new GrooveView((*this),_viewData) ;
-	_grooveView->AddObserver(*this) ;
+    _instrumentView = new InstrumentView((*this), _viewData);
+    _instrumentView->AddObserver((*this));
 
-	_mixerView=new MixerView((*this),_viewData) ;
-	_mixerView->AddObserver(*this) ;
+    _tableView = new TableView((*this), _viewData);
+    _tableView->AddObserver((*this));
 
-	_currentView=_songView ;
-	_currentView->OnFocus() ;
+    _grooveView = new GrooveView((*this), _viewData);
+    _grooveView->AddObserver(*this);
 
-	if (!playerOK) {
-		MessageBox *mb=new MessageBox(*_songView,"Failed to initialize audio",MBBF_OK) ;
-		_songView->DoModal(mb) ;
-	}
-	
-	Redraw() ;
+    _mixerView = new MixerView((*this), _viewData);
+    _mixerView->AddObserver(*this);
+
+    _currentView = _songView;
+    _currentView->OnFocus();
+
+    if (!playerOK) {
+        MessageBox *mb =
+            new MessageBox(*_songView, "Failed to initialize audio", MBBF_OK);
+        _songView->DoModal(mb);
+    }
+
+    Redraw();
 }
 
 void AppWindow::CloseProject() {
 
-	_closeProject=false ;
-	Player *player=Player::GetInstance() ;
-	player->Stop() ;
-	player->RemoveObserver(*this) ;
-	
-	player->Reset() ;
+    _closeProject = false;
+    Player *player = Player::GetInstance();
+    player->Stop();
+    player->RemoveObserver(*this);
 
-	SamplePool *pool=SamplePool::GetInstance() ;
-	pool->Reset() ;
+    player->Reset();
 
-	TableHolder::GetInstance()->Reset() ;
-	TablePlayback::Reset() ;
+    SamplePool *pool = SamplePool::GetInstance();
+    pool->Reset();
 
-	ApplicationCommandDispatcher::GetInstance()->Close() ;
+    TableHolder::GetInstance()->Reset();
+    TablePlayback::Reset();
 
-	SAFE_DELETE(_songView) ;
-	SAFE_DELETE(_chainView) ;
-	SAFE_DELETE(_phraseView) ;
-	SAFE_DELETE(_projectView) ;
-	SAFE_DELETE(_instrumentView) ;
-	SAFE_DELETE(_tableView);
+    ApplicationCommandDispatcher::GetInstance()->Close();
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->Reset() ;
+    SAFE_DELETE(_songView);
+    SAFE_DELETE(_chainView);
+    SAFE_DELETE(_phraseView);
+    SAFE_DELETE(_projectView);
+    SAFE_DELETE(_instrumentView);
+    SAFE_DELETE(_tableView);
 
-	SAFE_DELETE(_viewData) ;
+    UIController *controller = UIController::GetInstance();
+    controller->Reset();
 
-	_currentView=_nullView ;
-	_nullView->SetDirty(true) ;
+    SAFE_DELETE(_viewData);
 
-	SelectProjectDialog *spd=new SelectProjectDialog(*_currentView) ;
-	_currentView->DoModal(spd,ProjectSelectCallback) ;
-	
+    _currentView = _nullView;
+    _nullView->SetDirty(true);
 
-} ;
+    SelectProjectDialog *spd = new SelectProjectDialog(*_currentView);
+    _currentView->DoModal(spd, ProjectSelectCallback);
+};
 
 AppWindow *AppWindow::Create(GUICreateWindowParams &params) {
-	I_GUIWindowImp &imp=I_GUIWindowFactory::GetInstance()->CreateWindowImp(params) ;
-	AppWindow *w=new AppWindow(imp) ;
-	return w ;
-} ;
+    I_GUIWindowImp &imp =
+        I_GUIWindowFactory::GetInstance()->CreateWindowImp(params);
+    AppWindow *w = new AppWindow(imp);
+    return w;
+};
 
-void AppWindow::SetDirty() {
-	_isDirty=true ;
-} ;
+void AppWindow::SetDirty() { _isDirty = true; };
 
 bool AppWindow::onEvent(GUIEvent &event) {
 
-	// We need to tell the app to quit once we're out of the
-	// mixer lock, otherwise the windows driver will never return
+    // We need to tell the app to quit once we're out of the
+    // mixer lock, otherwise the windows driver will never return
 
-	_shouldQuit=false ;
+    _shouldQuit = false;
 
-	_isDirty=false ;
-		
-	unsigned short v=1<<event.GetValue();
+    _isDirty = false;
 
-	MixerService *sm=MixerService::GetInstance() ;
-	sm->Lock() ;
+    unsigned short v = 1 << event.GetValue();
 
-	switch(event.GetType())  {
- 
-		case ET_PADBUTTONDOWN:
+    MixerService *sm = MixerService::GetInstance();
+    sm->Lock();
 
- 			_mask|=v ;
-    	if (_currentView) _currentView->ProcessButton(_mask,true) ;
-			break ;
+    switch (event.GetType()) {
 
-		case ET_PADBUTTONUP:
+    case ET_PADBUTTONDOWN:
 
-			_mask&=(0xFFFF-v) ;
-    		if (_currentView) _currentView->ProcessButton(_mask,false) ;
-			break ;
+        _mask |= v;
+        if (_currentView)
+            _currentView->ProcessButton(_mask, true);
+        break;
 
-		case ET_SYSQUIT:
-			_shouldQuit=true ;
-			break ;
+    case ET_PADBUTTONUP:
 
-		/*		case ET_KEYDOWN:
-			if (event.GetValue()==EKT_ESCAPE&&!Player::GetInstance()->IsRunning()) {
-				if (_currentView!=_listView) {
-					CloseProject() ;
-					_isDirty=true ;
-				} else {
-					System::GetInstance()->PostQuitMessage() ;
-				};
-			} ;*/
+        _mask &= (0xFFFF - v);
+        if (_currentView)
+            _currentView->ProcessButton(_mask, false);
+        break;
 
-		default:
-			break ;
-	}
-	sm->Unlock() ;
+    case ET_SYSQUIT:
+        _shouldQuit = true;
+        break;
 
-	if (_shouldQuit) {
-		onQuitApp() ;
-	} 
-	if(_closeProject) {
-		CloseProject() ;
-		_isDirty=true ;
-	}
-	if(_loadAfterSaveAsProject) {
-	  CloseProject();
-	  _isDirty=true;
-	  LoadProject(_newProjectToLoad);
-	}
+        /*		case ET_KEYDOWN:
+            if
+           (event.GetValue()==EKT_ESCAPE&&!Player::GetInstance()->IsRunning()) {
+                if (_currentView!=_listView) {
+                    CloseProject() ;
+                    _isDirty=true ;
+                } else {
+                    System::GetInstance()->PostQuitMessage() ;
+                };
+            } ;*/
+
+    default:
+        break;
+    }
+    sm->Unlock();
+
+    if (_shouldQuit) {
+        onQuitApp();
+    }
+    if (_closeProject) {
+        CloseProject();
+        _isDirty = true;
+    }
+    if (_loadAfterSaveAsProject) {
+        CloseProject();
+        _isDirty = true;
+        LoadProject(_newProjectToLoad);
+    }
 #ifdef _SHOW_GP2X_
-	Redraw() ;
+    Redraw();
 #else
-	if (_isDirty) Redraw() ;
-#endif	
-	return false ;
-} ;
+    if (_isDirty)
+        Redraw();
+#endif
+    return false;
+};
 
 void AppWindow::onUpdate() {
-//	Redraw() ;
-	Flush() ;
-} ;
+    //	Redraw() ;
+    Flush();
+};
 
-void AppWindow::LayoutChildren() {
-} ;
+void AppWindow::LayoutChildren() {};
 
-void AppWindow::Update(Observable &o,I_ObservableData *d) {
+void AppWindow::Update(Observable &o, I_ObservableData *d) {
 
-	ViewEvent *ve=(ViewEvent *)d ;
+    ViewEvent *ve = (ViewEvent *)d;
 
-	switch(ve->GetType()) {
+    switch (ve->GetType()) {
 
-	  case VET_SWITCH_VIEW:
-	  {
-		ViewType *vt=(ViewType*)ve->GetData() ;
-		if (_currentView) {
-			_currentView->LooseFocus() ;
-		}
-		switch (*vt) {
-			case VT_SONG:
-			_currentView=_songView ;
-			break ;
-			case VT_CHAIN:
-			_currentView=_chainView ;
-			break ;
-			case VT_PHRASE:
-			_currentView=_phraseView ;
-			break ;
-			case VT_PROJECT:
-			_currentView=_projectView ;
-			break ;
-			case VT_INSTRUMENT:
-			_currentView=_instrumentView ;
-			break ;
-			case VT_TABLE:
-			_currentView=_tableView ;
-			break ;
-			case VT_TABLE2:
-			_currentView=_tableView ;
-			break ;
-			case VT_GROOVE:
-			_currentView=_grooveView ;
-			break ;
-/*			case VT_MIXER:
-			_currentView=_mixerView ;
-*/			break ;
-			
-		}
-		_currentView->SetFocus(*vt) ;
-		_isDirty=true ;
-		GUIWindow::Clear(backgroundColor_,true) ;
-		Clear(true);
-		Redraw() ;
-		break ;
-	  }
+    case VET_SWITCH_VIEW: {
+        ViewType *vt = (ViewType *)ve->GetData();
+        if (_currentView) {
+            _currentView->LooseFocus();
+        }
+        switch (*vt) {
+        case VT_SONG:
+            _currentView = _songView;
+            break;
+        case VT_CHAIN:
+            _currentView = _chainView;
+            break;
+        case VT_PHRASE:
+            _currentView = _phraseView;
+            break;
+        case VT_PROJECT:
+            _currentView = _projectView;
+            break;
+        case VT_INSTRUMENT:
+            _currentView = _instrumentView;
+            break;
+        case VT_TABLE:
+            _currentView = _tableView;
+            break;
+        case VT_TABLE2:
+            _currentView = _tableView;
+            break;
+        case VT_GROOVE:
+            _currentView = _grooveView;
+            break;
+            /*			case VT_MIXER:
+                        _currentView=_mixerView ;
+            */
+            break;
+        }
+        _currentView->SetFocus(*vt);
+        _isDirty = true;
+        GUIWindow::Clear(backgroundColor_, true);
+        Clear(true);
+        Redraw();
+        break;
+    }
 
-	  case VET_PLAYER_POSITION_UPDATE:
-	  {
-		PlayerEvent *pt=(PlayerEvent*)ve ;
+    case VET_PLAYER_POSITION_UPDATE: {
+        PlayerEvent *pt = (PlayerEvent *)ve;
 
-		if (_currentView) {
-			SysMutexLocker locker(drawMutex_) ;
-			_currentView->OnPlayerUpdate(pt->GetType(),pt->GetTickCount()) ;
-  		    Invalidate() ;
-		}
+        if (_currentView) {
+            SysMutexLocker locker(drawMutex_);
+            _currentView->OnPlayerUpdate(pt->GetType(), pt->GetTickCount());
+            Invalidate();
+        }
 
-		break ;
-	  }
+        break;
+    }
 
-/*	  case VET_LIST_SELECT:
-	  {
-		char *name=(char*)ve->GetData() ;
-		LoadProject(name) ;
-		break ;
-	  } */
+        /*	  case VET_LIST_SELECT:
+              {
+                char *name=(char*)ve->GetData() ;
+                LoadProject(name) ;
+                break ;
+              } */
 
-	  case VET_SAVEAS_PROJECT:
-	  {
-		char *name=(char*)ve->GetData() ;
-		_loadAfterSaveAsProject=true;
-		strcpy(_newProjectToLoad,name);
-		break ;
-	  }
+    case VET_SAVEAS_PROJECT: {
+        char *name = (char *)ve->GetData();
+        _loadAfterSaveAsProject = true;
+        strcpy(_newProjectToLoad, name);
+        break;
+    }
 
-	  case VET_QUIT_PROJECT:
-	  {
-   // defer event to after we got out of the view
-		_closeProject=true ;
-		break ;
-	  }
-	  case VET_QUIT_APP:
-		_shouldQuit=true ;
-		break ;
-   	}
-
+    case VET_QUIT_PROJECT: {
+        // defer event to after we got out of the view
+        _closeProject = true;
+        break;
+    }
+    case VET_QUIT_APP:
+        _shouldQuit = true;
+        break;
+    }
 }
 
 void AppWindow::onQuitApp() {
-	Player *player=Player::GetInstance() ;
-	player->Stop() ;
-	player->RemoveObserver(*this) ;
-	
-	player->Reset() ;
-	System::GetInstance()->PostQuitMessage() ;
+    Player *player = Player::GetInstance();
+    player->Stop();
+    player->RemoveObserver(*this);
+
+    player->Reset();
+    System::GetInstance()->PostQuitMessage();
 }
 void AppWindow::Print(char *line) {
 
-//	GUIWindow::Clear(View::backgroundColor_,true) ;
-	Clear() ;
-	strcpy(_statusLine,line) ;
-// unwrapped for gcc
-	int position=40 ;
-	position-=strlen(_statusLine) ;
-	position/=2 ;
-	GUIPoint pos(position,12) ;
-//
-	GUITextProperties props;
-	SetColor(CD_NORMAL) ;
-	DrawString(_statusLine,pos,props) ;
-	char buildString[80] ;
-	sprintf(buildString,"Piggy build %s.%s.%s",PROJECT_NUMBER,PROJECT_RELEASE,BUILD_COUNT) ;
-	pos._y=28 ;
-	pos._x=(40-strlen(buildString))/2 ;
-	DrawString(buildString,pos,props) ;
-	Flush() ;
-} ;
+    //	GUIWindow::Clear(View::backgroundColor_,true) ;
+    Clear();
+    strcpy(_statusLine, line);
+    // unwrapped for gcc
+    int position = 40;
+    position -= strlen(_statusLine);
+    position /= 2;
+    GUIPoint pos(position, 12);
+    //
+    GUITextProperties props;
+    SetColor(CD_NORMAL);
+    DrawString(_statusLine, pos, props);
+    char buildString[80];
+    sprintf(buildString, "Piggy build %s.%s.%s", PROJECT_NUMBER,
+            PROJECT_RELEASE, BUILD_COUNT);
+    pos._y = 28;
+    pos._x = (40 - strlen(buildString)) / 2;
+    DrawString(buildString, pos, props);
+    Flush();
+};
 
-void AppWindow::SetColor(ColorDefinition cd) {
-	colorIndex_=cd ;
-} ;
-
+void AppWindow::SetColor(ColorDefinition cd) { colorIndex_ = cd; };

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -2,117 +2,113 @@
 #ifndef _APP_WINDOW_H_
 #define _APP_WINDOW_H_
 
-#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
-#include "Foundation/Observable.h"
-#include "Application/Views/SongView.h"
 #include "Application/Views/ChainView.h"
-#include "Application/Views/PhraseView.h"
 #include "Application/Views/ConsoleView.h"
-#include "Application/Views/ProjectView.h"
-#include "Application/Views/InstrumentView.h"
-#include "Application/Views/TableView.h"
-#include "Application/Views/NullView.h"
-#include "Application/Views/MixerView.h"
 #include "Application/Views/GrooveView.h"
+#include "Application/Views/InstrumentView.h"
+#include "Application/Views/MixerView.h"
+#include "Application/Views/NullView.h"
+#include "Application/Views/PhraseView.h"
+#include "Application/Views/ProjectView.h"
+#include "Application/Views/SongView.h"
+#include "Application/Views/TableView.h"
 #include "Application/Views/ViewData.h"
-#include "System/io/Status.h"
+#include "Foundation/Observable.h"
 #include "System/Process/SysMutex.h"
+#include "System/io/Status.h"
+#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
 
 #define PROP_INVERT 0x80
 
-class AppWindow:public GUIWindow,I_Observer,Status {
-protected:
-	AppWindow(I_GUIWindowImp &imp) ;
-	virtual ~AppWindow() ;
+class AppWindow : public GUIWindow, I_Observer, Status {
+  protected:
+    AppWindow(I_GUIWindowImp &imp);
+    virtual ~AppWindow();
 
-public:
-	static AppWindow *Create(GUICreateWindowParams &) ;
-	void LoadProject(const Path &path) ;
-	void CloseProject() ;
+  public:
+    static AppWindow *Create(GUICreateWindowParams &);
+    void LoadProject(const Path &path);
+    void CloseProject();
 
-	virtual void Clear(bool all=false) ;
-	virtual void ClearRect(GUIRect &rect) ;
-	virtual void SetColor(ColorDefinition cd) ;
-	void SetDirty() ;
+    virtual void Clear(bool all = false);
+    virtual void ClearRect(GUIRect &rect);
+    virtual void SetColor(ColorDefinition cd);
+    void SetDirty();
 
-protected: // GUIWindow implementation
+  protected: // GUIWindow implementation
+    virtual bool onEvent(GUIEvent &event);
+    virtual void onUpdate();
+    virtual void LayoutChildren();
+    virtual void Flush();
+    virtual void Redraw();
 
-	virtual bool onEvent(GUIEvent &event) ;
-	virtual void onUpdate() ;
-	virtual void LayoutChildren() ;
-	virtual void Flush() ;
-	virtual void Redraw() ;
+    // override draw string to avoid going too far off
+    // the screen.
+    virtual void DrawString(const char *string, GUIPoint &pos,
+                            GUITextProperties &props, bool overlay = false);
 
-	// override draw string to avoid going too far off
-	// the screen.
-	virtual void DrawString(const char *string,GUIPoint &pos,GUITextProperties &props,bool overlay=false);
+    // I_Observer implementation
 
+    virtual void Update(Observable &o, I_ObservableData *d);
 
-      // I_Observer implementation
+    // Status implementation
 
-    virtual void Update(Observable &o,I_ObservableData *d) ;
+    virtual void Print(char *);
 
-	 // Status implementation
+    void defineColor(const char *colorName, GUIColor &color);
 
-	virtual void Print(char *) ;
+    void onQuitApp();
 
-    void defineColor(const char *colorName,GUIColor &color) ;
+  private:
+    View *_currentView;
+    ViewData *_viewData;
+    SongView *_songView;
+    ChainView *_chainView;
+    PhraseView *_phraseView;
+    ProjectView *_projectView;
+    InstrumentView *_instrumentView;
+    TableView *_tableView;
+    GrooveView *_grooveView;
+    NullView *_nullView;
+    MixerView *_mixerView;
 
-	void onQuitApp() ;
-private:
+    Path _root;
 
-	View *_currentView ;
-	ViewData *_viewData ;
-	SongView *_songView ;
-	ChainView *_chainView ;
-	PhraseView *_phraseView ;
-	ProjectView *_projectView ;
-	InstrumentView *_instrumentView ;
-	TableView *_tableView ;
-	GrooveView *_grooveView ;
-	NullView *_nullView ;
-	MixerView *_mixerView ;
+    bool _isDirty;
+    bool _closeProject;
+    bool _loadAfterSaveAsProject;
+    bool _shouldQuit;
+    unsigned short _mask;
+    unsigned long _lastA;
+    unsigned long _lastB;
+    char _statusLine[80];
+    char _newProjectToLoad[80];
+    unsigned char _charScreen[1200];
+    unsigned char _charScreenProp[1200];
+    unsigned char _preScreen[1200];
+    unsigned char _preScreenProp[1200];
 
-	Path _root ;
-
-	bool _isDirty ;
-	bool _closeProject ;
-	bool _loadAfterSaveAsProject ;
-	bool _shouldQuit ;
-	unsigned short _mask ;
-	unsigned long _lastA ;
-	unsigned long _lastB ;
-	char _statusLine[80] ;
-	char _newProjectToLoad[80];
-	unsigned char _charScreen[1200] ;
-	unsigned char _charScreenProp[1200] ;
-	unsigned char _preScreen[1200] ;
-	unsigned char _preScreenProp[1200] ;
-
-    static GUIColor backgroundColor_ ;
-    static GUIColor normalColor_ ;
-    static GUIColor borderColor_ ;
-	static GUIColor songviewfeColor_ ;
-	static GUIColor songview00Color_ ;
+    static GUIColor backgroundColor_;
+    static GUIColor normalColor_;
+    static GUIColor borderColor_;
+    static GUIColor songviewfeColor_;
+    static GUIColor songview00Color_;
     static GUIColor highlight2Color_;
     static GUIColor highlightColor_;
     static GUIColor consoleColor_;
     static GUIColor cursorColor_;
-    static GUIColor playColor_ ;
-    static GUIColor muteColor_ ;
+    static GUIColor playColor_;
+    static GUIColor muteColor_;
     static GUIColor rownumberColor_;
     static GUIColor rownumber2Color_;
-	static GUIColor majorbeatColor_;
+    static GUIColor majorbeatColor_;
 
-	ColorDefinition colorIndex_ ;
+    ColorDefinition colorIndex_;
 
-	static int charWidth_ ;
-	static int charHeight_ ;
-	
-	SysMutex drawMutex_ ;
-} ;
+    static int charWidth_;
+    static int charHeight_;
 
-
+    SysMutex drawMutex_;
+};
 
 #endif
-

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -91,12 +91,15 @@ private:
 
     static GUIColor backgroundColor_ ;
     static GUIColor normalColor_ ;
+    static GUIColor borderColor_ ;
 	static GUIColor songviewfeColor_ ;
 	static GUIColor songview00Color_ ;
     static GUIColor highlight2Color_;
     static GUIColor highlightColor_;
     static GUIColor consoleColor_;
     static GUIColor cursorColor_;
+    static GUIColor playColor_ ;
+    static GUIColor muteColor_ ;
     static GUIColor rownumberColor_;
     static GUIColor rownumber2Color_;
 	static GUIColor majorbeatColor_;

--- a/sources/Application/Views/BaseClasses/ModalView.cpp
+++ b/sources/Application/Views/BaseClasses/ModalView.cpp
@@ -46,7 +46,7 @@ void ModalView::SetWindow(int width,int height) {
 	}
 	ClearRect(-1,-1,width+2,height+2) ;
 
-	SetColor(CD_HILITE2) ;
+	SetColor(CD_BORDER) ;
 	GUITextProperties props ;
 	props.invert_=true ;
 	char line[41] ;

--- a/sources/Application/Views/BaseClasses/ModalView.cpp
+++ b/sources/Application/Views/BaseClasses/ModalView.cpp
@@ -1,9 +1,9 @@
 #include "ModalView.h"
 
 ModalView::ModalView(View &v)
-    : View(v.w_, v.viewData_), finished_(false), returnCode_(0) {};
+    : View(v.w_, v.viewData_), finished_(false), returnCode_(0){};
 
-ModalView::~ModalView() {};
+ModalView::~ModalView(){};
 
 int ModalView::GetReturnCode() { return returnCode_; };
 

--- a/sources/Application/Views/BaseClasses/ModalView.cpp
+++ b/sources/Application/Views/BaseClasses/ModalView.cpp
@@ -1,62 +1,54 @@
 #include "ModalView.h"
 
-ModalView::ModalView(View &v):
-	View(v.w_,v.viewData_),
-	finished_(false),
-	returnCode_(0) {
-} ;
+ModalView::ModalView(View &v)
+    : View(v.w_, v.viewData_), finished_(false), returnCode_(0) {};
 
-ModalView::~ModalView() {
-} ;
+ModalView::~ModalView() {};
 
-int ModalView::GetReturnCode() {
-	return returnCode_ ;
-} ;
+int ModalView::GetReturnCode() { return returnCode_; };
 
-bool ModalView::IsFinished() {
-	return finished_ ;
-} ;
+bool ModalView::IsFinished() { return finished_; };
 
 void ModalView::EndModal(int returnCode) {
-	returnCode_=returnCode ;
-	finished_=true ;
-} ;
+    returnCode_ = returnCode;
+    finished_ = true;
+};
 
-void ModalView::ClearRect(int x,int y,int w,int h) {
-	View::ClearRect(x+left_,y+top_,w,h) ;
+void ModalView::ClearRect(int x, int y, int w, int h) {
+    View::ClearRect(x + left_, y + top_, w, h);
 }
-void ModalView::DrawString(int x,int y,const char *txt,GUITextProperties &props) {
-	View::DrawString(x+left_,y+top_,txt,props) ;
-} ;
+void ModalView::DrawString(int x, int y, const char *txt,
+                           GUITextProperties &props) {
+    View::DrawString(x + left_, y + top_, txt, props);
+};
 
+void ModalView::SetWindow(int width, int height) {
 
-void ModalView::SetWindow(int width,int height) {
+    if (width > 36) {
+        width = 36;
+    };
+    if (height > 26) {
+        height = 26;
+    };
 
-	if (width>36) {
-		width=36 ;
-	} ;
-	if (height>26) {
-		height=26 ;
-	} ;
-	
-	left_=20-width/2 ;
-	top_=10-height/2 ;
-	if (top_<2) {
-		top_=2 ;
-	}
-	ClearRect(-1,-1,width+2,height+2) ;
+    left_ = 20 - width / 2;
+    top_ = 10 - height / 2;
+    if (top_ < 2) {
+        top_ = 2;
+    }
+    ClearRect(-1, -1, width + 2, height + 2);
 
-	SetColor(CD_BORDER) ;
-	GUITextProperties props ;
-	props.invert_=true ;
-	char line[41] ;
-	memset(line,' ',40) ;
-	line[width+4]=0 ;
-	DrawString(-2,-2,line,props) ;
-	DrawString(-2,height+1,line,props) ;
-	line[1]=0 ;
-	for (int i=0;i<height+2;i++) {
-		DrawString(-2,i-1,line,props) ;
-		DrawString(width+1,i-1,line,props) ;
-	}
-} ;
+    SetColor(CD_BORDER);
+    GUITextProperties props;
+    props.invert_ = true;
+    char line[41];
+    memset(line, ' ', 40);
+    line[width + 4] = 0;
+    DrawString(-2, -2, line, props);
+    DrawString(-2, height + 1, line, props);
+    line[1] = 0;
+    for (int i = 0; i < height + 2; i++) {
+        DrawString(-2, i - 1, line, props);
+        DrawString(width + 1, i - 1, line, props);
+    }
+};

--- a/sources/Application/Views/BaseClasses/ModalView.h
+++ b/sources/Application/Views/BaseClasses/ModalView.h
@@ -4,23 +4,25 @@
 
 #include "View.h"
 
-class ModalView: public View {
-public:
-	ModalView(View &) ;
-	virtual ~ModalView() ;
+class ModalView : public View {
+  public:
+    ModalView(View &);
+    virtual ~ModalView();
 
-	bool IsFinished() ;
-	int GetReturnCode() ;
+    bool IsFinished();
+    int GetReturnCode();
 
-protected:
-	void SetWindow(int width,int height) ;
-	virtual void ClearRect(int x,int y,int w,int h) ;
-	virtual void DrawString(int x,int y,const char *txt,GUITextProperties &props) ;
-	void EndModal(int returnCode) ;
-private:
-	bool finished_ ;
-	int returnCode_ ;
-	int left_ ;
-	int top_ ;
-} ;
+  protected:
+    void SetWindow(int width, int height);
+    virtual void ClearRect(int x, int y, int w, int h);
+    virtual void DrawString(int x, int y, const char *txt,
+                            GUITextProperties &props);
+    void EndModal(int returnCode);
+
+  private:
+    bool finished_;
+    int returnCode_;
+    int left_;
+    int top_;
+};
 #endif

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -2,14 +2,14 @@
 #ifndef _VIEW_H_
 #define _VIEW_H_
 
-#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
-#include "UIFramework/Interfaces/I_GUIGraphics.h"
-#include "ViewEvent.h"
+#include "Application/Model/Config.h"
 #include "Application/Model/Project.h"
 #include "Application/Player/Player.h"
 #include "Foundation/T_SimpleList.h"
-#include "Application/Model/Config.h"
 #include "I_Action.h"
+#include "UIFramework/Interfaces/I_GUIGraphics.h"
+#include "UIFramework/SimpleBaseClasses/GUIWindow.h"
+#include "ViewEvent.h"
 #ifdef SDL2
 #include <SDL2/SDL.h>
 #else
@@ -17,161 +17,160 @@
 #endif
 
 enum GUIEventPadButtonMasks {
-EPBM_LEFT=1,
-EPBM_DOWN=2,
-EPBM_RIGHT=4, 
-EPBM_UP=8, 
-EPBM_L=16, 
-EPBM_B=32, 
-EPBM_A=64, 
-EPBM_R=128, 
-EPBM_START=256, 
-EPBM_SELECT=512,
-EPBM_DOUBLE_A=1024,
-EPBM_DOUBLE_B=2048 
-} ;
+    EPBM_LEFT = 1,
+    EPBM_DOWN = 2,
+    EPBM_RIGHT = 4,
+    EPBM_UP = 8,
+    EPBM_L = 16,
+    EPBM_B = 32,
+    EPBM_A = 64,
+    EPBM_R = 128,
+    EPBM_START = 256,
+    EPBM_SELECT = 512,
+    EPBM_DOUBLE_A = 1024,
+    EPBM_DOUBLE_B = 2048
+};
 
 enum ViewType {
-VT_SONG,
-VT_CHAIN,
-VT_PHRASE,
-VT_PROJECT,
-VT_INSTRUMENT,
-VT_TABLE,  // Table screen under phrase
-VT_TABLE2,  // Table screen under instrument
-VT_GROOVE,
-VT_MIXER
-} ;
+    VT_SONG,
+    VT_CHAIN,
+    VT_PHRASE,
+    VT_PROJECT,
+    VT_INSTRUMENT,
+    VT_TABLE,  // Table screen under phrase
+    VT_TABLE2, // Table screen under instrument
+    VT_GROOVE,
+    VT_MIXER
+};
 
 enum ViewMode {
-	VM_NORMAL,
-	VM_NEW,
-	VM_CLONE,
-	VM_SELECTION,
-	VM_MUTEON,
-	VM_SOLOON
-} ;
+    VM_NORMAL,
+    VM_NEW,
+    VM_CLONE,
+    VM_SELECTION,
+    VM_MUTEON,
+    VM_SOLOON
+};
 
 enum ColorDefinition {
-	CD_BACKGROUND,
-	CD_NORMAL,
+    CD_BACKGROUND,
+    CD_NORMAL,
     CD_BORDER,
-	CD_HILITE1,
-	CD_HILITE2,
-	CD_CONSOLE,
-	CD_CURSOR,
+    CD_HILITE1,
+    CD_HILITE2,
+    CD_CONSOLE,
+    CD_CURSOR,
     CD_PLAY,
     CD_MUTE,
-	CD_SONGVIEWFE,
-	CD_SONGVIEW00,
-	CD_ROW,
-	CD_ROW2,
-	CD_MAJORBEAT
-} ;
+    CD_SONGVIEWFE,
+    CD_SONGVIEW00,
+    CD_ROW,
+    CD_ROW2,
+    CD_MAJORBEAT
+};
 
-enum ViewUpdateDirection {
-	VUD_LEFT=0,
-	VUD_RIGHT,
-	VUD_UP,
-	VUD_DOWN
-} ;
+enum ViewUpdateDirection { VUD_LEFT = 0, VUD_RIGHT, VUD_UP, VUD_DOWN };
 
-class View ;
-class ModalView ;
+class View;
+class ModalView;
 
-typedef void (*ModalViewCallback) (View &v,ModalView &d) ;
+typedef void (*ModalViewCallback)(View &v, ModalView &d);
 
-class View: public Observable {
-public:
-	View(GUIWindow &w,ViewData *viewData) ;
-	View(View &v) ;
+class View : public Observable {
+  public:
+    View(GUIWindow &w, ViewData *viewData);
+    View(View &v);
 
-	void SetFocus(ViewType vt) {
-		viewType_=vt ;
-		hasFocus_=true ;
-		OnFocus() ;
-	};
+    void SetFocus(ViewType vt) {
+        viewType_ = vt;
+        hasFocus_ = true;
+        OnFocus();
+    };
 
-	void LooseFocus() {
-		hasFocus_=false ;
-	} ;
+    void LooseFocus() { hasFocus_ = false; };
 
-	void Clear() ;
+    void Clear();
 
-	void ProcessButton(unsigned short mask, bool pressed) ;
+    void ProcessButton(unsigned short mask, bool pressed);
 
-	void Redraw() ;
+    void Redraw();
 
- // Override in subclasses
+    // Override in subclasses
 
-	virtual void DrawView()=0 ;
-	virtual void OnPlayerUpdate(PlayerEventType ,unsigned int currentTick)=0 ;
-	virtual void OnFocus()=0 ;
+    virtual void DrawView() = 0;
+    virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick) = 0;
+    virtual void OnFocus() = 0;
 
-	void SetDirty(bool dirty) ;
-	
- // Primitive locking mechanism
+    void SetDirty(bool dirty);
 
-	bool Lock() ;
-	void WaitForObject() ;
-	void Unlock() ;
+    // Primitive locking mechanism
 
- // Char based draw routines
+    bool Lock();
+    void WaitForObject();
+    void Unlock();
 
-	virtual void SetColor(ColorDefinition cd) ;
-	virtual void ClearRect(int x,int y,int w,int h) ;
-	virtual void DrawString(int x,int y,const char *txt,GUITextProperties &props) ;
+    // Char based draw routines
 
-	void DoModal(ModalView *view,ModalViewCallback cb=0) ;
+    virtual void SetColor(ColorDefinition cd);
+    virtual void ClearRect(int x, int y, int w, int h);
+    virtual void DrawString(int x, int y, const char *txt,
+                            GUITextProperties &props);
 
-	void EnableNotification();
-	void SetNotification(const char *notification);
+    void DoModal(ModalView *view, ModalViewCallback cb = 0);
 
-protected: 
+    void EnableNotification();
+    void SetNotification(const char *notification);
 
-	virtual void ProcessButtonMask(unsigned short mask,bool pressed)=0 ;
+  protected:
+    virtual void ProcessButtonMask(unsigned short mask, bool pressed) = 0;
 
- // to remove once everything got to viewdata
+    // to remove once everything got to viewdata
 
-	inline void updateData(unsigned char *c,int offset,unsigned char limit,bool wrap) {
-		int v=*c ;
-		if (v==0xFF) { // Uninitiaized data
-			v=0 ;
-		}
-		v+=offset ;
-		if (v<0) v=(wrap?(limit+1+v):0) ;
-		if (v>limit) v=(wrap?v-(limit+1):limit) ;
-		*c=v ;
-	}
+    inline void updateData(unsigned char *c, int offset, unsigned char limit,
+                           bool wrap) {
+        int v = *c;
+        if (v == 0xFF) { // Uninitiaized data
+            v = 0;
+        }
+        v += offset;
+        if (v < 0)
+            v = (wrap ? (limit + 1 + v) : 0);
+        if (v > limit)
+            v = (wrap ? v - (limit + 1) : limit);
+        *c = v;
+    }
 
-	GUIPoint GetAnchor() ;
-	GUIPoint GetTitlePosition() ;
+    GUIPoint GetAnchor();
+    GUIPoint GetTitlePosition();
 
-    void drawMap() ;
-    void drawNotes() ;
-public: // temp hack for modl windo constructors
-	GUIWindow &w_ ;
-	ViewData *viewData_ ;
-protected:
-	ViewMode viewMode_ ;
-	bool isDirty_ ;              // .Do we need to redraw screeen
-	ViewType viewType_ ;	
-	bool hasFocus_ ;
+    void drawMap();
+    void drawNotes();
 
-private:
-	unsigned short mask_ ;	
-	bool locked_ ;
-	uint32_t notificationTime_;
-	uint16_t NOTIFICATION_TIMEOUT;
-	char* displayNotification_;
-	static bool initPrivate_ ;
-	ModalView *modalView_ ;
-	ModalViewCallback modalViewCallback_ ;
-public:
-	static int margin_ ;
-	static int songRowCount_ ;
-	static bool miniLayout_ ;
-	static int altRowNumber_;
-} ;
+  public: // temp hack for modl windo constructors
+    GUIWindow &w_;
+    ViewData *viewData_;
+
+  protected:
+    ViewMode viewMode_;
+    bool isDirty_; // .Do we need to redraw screeen
+    ViewType viewType_;
+    bool hasFocus_;
+
+  private:
+    unsigned short mask_;
+    bool locked_;
+    uint32_t notificationTime_;
+    uint16_t NOTIFICATION_TIMEOUT;
+    char *displayNotification_;
+    static bool initPrivate_;
+    ModalView *modalView_;
+    ModalViewCallback modalViewCallback_;
+
+  public:
+    static int margin_;
+    static int songRowCount_;
+    static bool miniLayout_;
+    static int altRowNumber_;
+};
 
 #endif

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -55,10 +55,13 @@ enum ViewMode {
 enum ColorDefinition {
 	CD_BACKGROUND,
 	CD_NORMAL,
+    CD_BORDER,
 	CD_HILITE1,
 	CD_HILITE2,
 	CD_CONSOLE,
 	CD_CURSOR,
+    CD_PLAY,
+    CD_MUTE,
 	CD_SONGVIEWFE,
 	CD_SONGVIEW00,
 	CD_ROW,

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -725,11 +725,13 @@ void ChainView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
 		            viewData_->playMode_ != PM_AUDITION) {
     				pos._y=anchor._y+viewData_->chainPlayPos_[i] ;
     				if (!player->IsChannelMuted(i)) {
-						SetColor(CD_CURSOR) ;
-    					DrawString(pos._x,pos._y,">",props) ;
-    					SetColor(CD_NORMAL) ;
+						SetColor(CD_PLAY);
+						DrawString(pos._x,pos._y,">",props);
+    					SetColor(CD_NORMAL);
     				} else {
-    					DrawString(pos._x,pos._y,"-",props) ;
+                        SetColor(CD_MUTE);
+						DrawString(pos._x,pos._y,"-",props);
+						SetColor(CD_NORMAL);
     				}
     				lastPlayingPos_=viewData_->chainPlayPos_[i] ;
     				break ;

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -1,246 +1,250 @@
 #include "ChainView.h"
-#include "System/Console/Trace.h"
 #include "Application/Utils/char.h"
+#include "System/Console/Trace.h"
 #include "UIController.h"
 
- 
-ChainView::ChainView(GUIWindow &w,ViewData *viewData):View(w,viewData) {
-	updatingPhrase_=false ;
-	lastPhrase_=0 ;
-	lastPlayingPos_=0 ;
-	lastQueuedPos_=0 ;
-	
-	clipboard_.active_=false ;
-	clipboard_.width_=0 ;
-	clipboard_.height_=0 ;
-	
-	for (int i=0;i<16;i++) {
-		clipboard_.phrase_[i]=0xFF ;
-		clipboard_.transpose_[i]=0 ;
-	} ;
+ChainView::ChainView(GUIWindow &w, ViewData *viewData) : View(w, viewData) {
+    updatingPhrase_ = false;
+    lastPhrase_ = 0;
+    lastPlayingPos_ = 0;
+    lastQueuedPos_ = 0;
+
+    clipboard_.active_ = false;
+    clipboard_.width_ = 0;
+    clipboard_.height_ = 0;
+
+    for (int i = 0; i < 16; i++) {
+        clipboard_.phrase_[i] = 0xFF;
+        clipboard_.transpose_[i] = 0;
+    };
 }
 
 void ChainView::setPhrase(unsigned char value) {
-	viewData_->SetChainPhrase(value) ;
-	lastPhrase_=value ;
-	isDirty_=true ;
+    viewData_->SetChainPhrase(value);
+    lastPhrase_ = value;
+    isDirty_ = true;
 }
 
 void ChainView::cutPosition() {
-    clipboard_.active_=true ;
-    clipboard_.row_=viewData_->chainRow_ ;
-    clipboard_.col_=viewData_->chainCol_ ;
-	saveRow_=viewData_->chainRow_ ;
-	saveCol_=viewData_->chainCol_ ;
-    cutSelection() ;
-} ;
+    clipboard_.active_ = true;
+    clipboard_.row_ = viewData_->chainRow_;
+    clipboard_.col_ = viewData_->chainCol_;
+    saveRow_ = viewData_->chainRow_;
+    saveCol_ = viewData_->chainCol_;
+    cutSelection();
+};
 
 void ChainView::pasteLastPhrase() {
 
-	 // If we're on an empty spot, we past the last phrase
-	 // otherwise we take the current phrase as last
+    // If we're on an empty spot, we past the last phrase
+    // otherwise we take the current phrase as last
 
-    unsigned char *c=viewData_->GetCurrentChainPointer() ;
-	if ((*c==0xFF)) {
-		*c=lastPhrase_ ;
-		isDirty_=true ;
-	} else {
-		lastPhrase_=*c ;
-	}
-} ;
+    unsigned char *c = viewData_->GetCurrentChainPointer();
+    if ((*c == 0xFF)) {
+        *c = lastPhrase_;
+        isDirty_ = true;
+    } else {
+        lastPhrase_ = *c;
+    }
+};
 
-void ChainView::updateCursor(int dx,int dy) {
-	viewData_->UpdateChainCursor(dx,dy) ;
-	isDirty_=true;
+void ChainView::updateCursor(int dx, int dy) {
+    viewData_->UpdateChainCursor(dx, dy);
+    isDirty_ = true;
 }
 
-void ChainView::updateCursorValue(int offset,int dx,int dy) {
+void ChainView::updateCursorValue(int offset, int dx, int dy) {
 
-	unsigned char v=viewData_->UpdateChainCursorValue(offset,dx,dy) ;
-	if (viewData_->chainCol_==0) {
-		lastPhrase_=v ;
-		updatingPhrase_=true ;
-		updateRow_=viewData_->chainRow_ ;
-	}
-	isDirty_=true ;
+    unsigned char v = viewData_->UpdateChainCursorValue(offset, dx, dy);
+    if (viewData_->chainCol_ == 0) {
+        lastPhrase_ = v;
+        updatingPhrase_ = true;
+        updateRow_ = viewData_->chainRow_;
+    }
+    isDirty_ = true;
 }
 
 void ChainView::updateSelectionValue(int offset) { // HERE
 
-	int savecol=viewData_->chainCol_ ;
-	int saverow=viewData_->chainRow_ ;
-	GUIRect r=getSelectionRect() ;
-	viewData_->chainCol_=r.Left() ;
-    viewData_->chainRow_ =r.Top() ;
-	for (int i=0;i<=r.Width();i++) {
-		for (int j=0;j<=r.Height();j++) {
-			updateCursorValue(offset,i,j) ;
-		}
-	}
-	viewData_->chainCol_=savecol ;
-    viewData_->chainRow_ =saverow ;
+    int savecol = viewData_->chainCol_;
+    int saverow = viewData_->chainRow_;
+    GUIRect r = getSelectionRect();
+    viewData_->chainCol_ = r.Left();
+    viewData_->chainRow_ = r.Top();
+    for (int i = 0; i <= r.Width(); i++) {
+        for (int j = 0; j <= r.Height(); j++) {
+            updateCursorValue(offset, i, j);
+        }
+    }
+    viewData_->chainCol_ = savecol;
+    viewData_->chainRow_ = saverow;
 }
 
 void ChainView::warpInColumn(int offset) {
-	// save current data
-	int saveY = viewData_->songY_ ;
-	int saveOffset = viewData_->songOffset_ ;
+    // save current data
+    int saveY = viewData_->songY_;
+    int saveOffset = viewData_->songOffset_;
 
-	// Jumping more than the rows displayed on screen causes infinite loop
-	while (viewData_->songY_ >= 0 && viewData_->songY_ < 21) {
-		viewData_->UpdateSongCursor(0,offset) ;
-		unsigned char *data=viewData_->GetCurrentSongPointer() ;
-		if (*data!=0xFF) {
-			viewData_->currentChain_=*data ;
-			isDirty_=true ;
-			return;
-		}
-	}
-	// restore old position
-	viewData_->songY_ = saveY;
-	viewData_->songOffset_ = saveOffset;
-} ;
+    // Jumping more than the rows displayed on screen causes infinite loop
+    while (viewData_->songY_ >= 0 && viewData_->songY_ < 21) {
+        viewData_->UpdateSongCursor(0, offset);
+        unsigned char *data = viewData_->GetCurrentSongPointer();
+        if (*data != 0xFF) {
+            viewData_->currentChain_ = *data;
+            isDirty_ = true;
+            return;
+        }
+    }
+    // restore old position
+    viewData_->songY_ = saveY;
+    viewData_->songOffset_ = saveOffset;
+};
 
 void ChainView::warpToNeighbour(int offset) {
-	// save current data
-	int saveX = viewData_->songX_;
-	int saveOffset = viewData_->songOffset_;
-	int newPos = saveX + offset;
+    // save current data
+    int saveX = viewData_->songX_;
+    int saveOffset = viewData_->songOffset_;
+    int newPos = saveX + offset;
 
-	while ((newPos > -1) && (newPos<SONG_CHANNEL_COUNT)) {
-		viewData_->songX_=newPos ;
-		unsigned char *c=viewData_->GetCurrentSongPointer() ;
-		if (*c!=0xFF) {
-			viewData_->currentChain_=*c ;
-			isDirty_=true ;
-			return;
-		} else {
-			newPos += offset;
-		}
-	}
-	viewData_->songX_ = saveX;
-	viewData_->songOffset_ = saveOffset;
-} ;
+    while ((newPos > -1) && (newPos < SONG_CHANNEL_COUNT)) {
+        viewData_->songX_ = newPos;
+        unsigned char *c = viewData_->GetCurrentSongPointer();
+        if (*c != 0xFF) {
+            viewData_->currentChain_ = *c;
+            isDirty_ = true;
+            return;
+        } else {
+            newPos += offset;
+        }
+    }
+    viewData_->songX_ = saveX;
+    viewData_->songOffset_ = saveOffset;
+};
 
 void ChainView::clonePosition() {
 
-    unsigned char *pos=viewData_->GetCurrentChainPointer() ;
-    unsigned char current=*pos ;
-	if (current==255) return ;
+    unsigned char *pos = viewData_->GetCurrentChainPointer();
+    unsigned char current = *pos;
+    if (current == 255)
+        return;
 
-    unsigned short next=viewData_->song_->phrase_->GetNext() ;
-	if (next==NO_MORE_PHRASE) return ;
+    unsigned short next = viewData_->song_->phrase_->GetNext();
+    if (next == NO_MORE_PHRASE)
+        return;
 
-    unsigned char *src=viewData_->song_->phrase_->note_+16*current ;
-    unsigned char *dst=viewData_->song_->phrase_->note_+16*next ;
-    for (int i=0;i<16;i++) {
-        *dst++=*src++ ;
-    } ;
+    unsigned char *src = viewData_->song_->phrase_->note_ + 16 * current;
+    unsigned char *dst = viewData_->song_->phrase_->note_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *dst++ = *src++;
+    };
 
-    src=viewData_->song_->phrase_->instr_+16*current ;
-    dst=viewData_->song_->phrase_->instr_+16*next ;
-    for (int i=0;i<16;i++) {
-        *dst++=*src++ ;
-    } ;
+    src = viewData_->song_->phrase_->instr_ + 16 * current;
+    dst = viewData_->song_->phrase_->instr_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *dst++ = *src++;
+    };
 
-    uint *isrc=viewData_->song_->phrase_->cmd1_+16*current ;
-    uint *idst=viewData_->song_->phrase_->cmd1_+16*next ;
-    for (int i=0;i<16;i++) {
-        *idst++=*isrc++ ;
-    } ;
+    uint *isrc = viewData_->song_->phrase_->cmd1_ + 16 * current;
+    uint *idst = viewData_->song_->phrase_->cmd1_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *idst++ = *isrc++;
+    };
 
-    ushort *ssrc=viewData_->song_->phrase_->param1_+16*current ;
-    ushort *sdst=viewData_->song_->phrase_->param1_+16*next ;
-    for (int i=0;i<16;i++) {
-        *sdst++=*ssrc++ ;
-    } ;
-    
-    isrc=viewData_->song_->phrase_->cmd2_+16*current ;
-    idst=viewData_->song_->phrase_->cmd2_+16*next ;
-    for (int i=0;i<16;i++) {
-        *idst++=*isrc++ ;
-    } ;
-    
-    ssrc=viewData_->song_->phrase_->param2_+16*current ;
-    sdst=viewData_->song_->phrase_->param2_+16*next ;
-    for (int i=0;i<16;i++) {
-        *sdst++=*ssrc++ ;
-    } ;
-    
-    setPhrase((unsigned char)next) ;
-    isDirty_=true ;
-} ;
+    ushort *ssrc = viewData_->song_->phrase_->param1_ + 16 * current;
+    ushort *sdst = viewData_->song_->phrase_->param1_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *sdst++ = *ssrc++;
+    };
+
+    isrc = viewData_->song_->phrase_->cmd2_ + 16 * current;
+    idst = viewData_->song_->phrase_->cmd2_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *idst++ = *isrc++;
+    };
+
+    ssrc = viewData_->song_->phrase_->param2_ + 16 * current;
+    sdst = viewData_->song_->phrase_->param2_ + 16 * next;
+    for (int i = 0; i < 16; i++) {
+        *sdst++ = *ssrc++;
+    };
+
+    setPhrase((unsigned char)next);
+    isDirty_ = true;
+};
 
 /******************************************************
  getSelectionRect:
         gets the normalized rectangle of the current
         selection. Valid only while selection is drawn
  ******************************************************/
- 
+
 GUIRect ChainView::getSelectionRect() {
-    GUIRect r(clipboard_.col_,clipboard_.row_,viewData_->chainCol_,viewData_->chainRow_) ;
-    r.Normalize() ;
-    return r ;
-} ;
+    GUIRect r(clipboard_.col_, clipboard_.row_, viewData_->chainCol_,
+              viewData_->chainRow_);
+    r.Normalize();
+    return r;
+};
 
 /******************************************************
  fillClipboardData:
-        
+
         copies the necessary information from the
         current selection to the clipboard for future
         paste. We're copying data all across the row
         because we"re too lazy to try to figure a better
         procedure
  ******************************************************/
- 
+
 void ChainView::fillClipboardData() {
 
-  // Get Current normalized selection rect
-  
-    GUIRect selRect=getSelectionRect() ;
+    // Get Current normalized selection rect
 
-  // Get size & store in clipboard
-  
-    clipboard_.width_=selRect.Width()+1 ;
-    clipboard_.height_=selRect.Height()+1 ;
-    clipboard_.row_=selRect.Top() ; ;
-    clipboard_.col_=selRect.Left() ;
-  
- // Copy the data
-    
-    unsigned char *src1=viewData_->song_->chain_->data_+16*viewData_->currentChain_ ;
-    unsigned char *dst1=clipboard_.phrase_ ;
-    unsigned char *src2=viewData_->song_->chain_->transpose_+16*viewData_->currentChain_ ;
-    unsigned char *dst2=clipboard_.transpose_ ;   
-    
-    for (int i=0;i<clipboard_.height_;i++) {
-        dst1[i]=src1[clipboard_.row_+i] ;
-        dst2[i]=src2[clipboard_.row_+i] ;
-    } ;
-       
-} ;
+    GUIRect selRect = getSelectionRect();
+
+    // Get size & store in clipboard
+
+    clipboard_.width_ = selRect.Width() + 1;
+    clipboard_.height_ = selRect.Height() + 1;
+    clipboard_.row_ = selRect.Top();
+    ;
+    clipboard_.col_ = selRect.Left();
+
+    // Copy the data
+
+    unsigned char *src1 =
+        viewData_->song_->chain_->data_ + 16 * viewData_->currentChain_;
+    unsigned char *dst1 = clipboard_.phrase_;
+    unsigned char *src2 =
+        viewData_->song_->chain_->transpose_ + 16 * viewData_->currentChain_;
+    unsigned char *dst2 = clipboard_.transpose_;
+
+    for (int i = 0; i < clipboard_.height_; i++) {
+        dst1[i] = src1[clipboard_.row_ + i];
+        dst2[i] = src2[clipboard_.row_ + i];
+    };
+};
 
 void ChainView::extendSelection() {
-	GUIRect rect=getSelectionRect() ;
-	if (rect.Left()>0||rect.Right()<1) {
-		if (viewData_->chainCol_<clipboard_.col_) {
-			viewData_->chainCol_=0 ;
-			clipboard_.col_=1 ;
-		} else {
-			viewData_->chainCol_=1 ;
-			clipboard_.col_=0 ;
-		}
-		isDirty_=true ;
-	} else {
-		if (viewData_->chainRow_<clipboard_.row_) {
-			viewData_->chainRow_=0 ;
-			clipboard_.row_=15 ;
-		} else {
-			clipboard_.row_=0 ;
-			viewData_->chainRow_=15 ;
-		}
-		isDirty_=true ;
-	}
+    GUIRect rect = getSelectionRect();
+    if (rect.Left() > 0 || rect.Right() < 1) {
+        if (viewData_->chainCol_ < clipboard_.col_) {
+            viewData_->chainCol_ = 0;
+            clipboard_.col_ = 1;
+        } else {
+            viewData_->chainCol_ = 1;
+            clipboard_.col_ = 0;
+        }
+        isDirty_ = true;
+    } else {
+        if (viewData_->chainRow_ < clipboard_.row_) {
+            viewData_->chainRow_ = 0;
+            clipboard_.row_ = 15;
+        } else {
+            clipboard_.row_ = 0;
+            viewData_->chainRow_ = 15;
+        }
+        isDirty_ = true;
+    }
 }
 
 /******************************************************
@@ -248,66 +252,68 @@ void ChainView::extendSelection() {
         copies data in the current selection to the
         clipboard & end selection process
  ******************************************************/
- 
+
 void ChainView::copySelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
- 
-//	saveClipboardPosition() ;
-    
-    fillClipboardData() ;
-    
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
 
-    viewData_->chainRow_=saveRow_ ; 
-    viewData_->chainCol_=saveCol_ ;
+    //	saveClipboardPosition() ;
 
-	View::SetNotification("copied selection");
-} ;
+    fillClipboardData();
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+
+    viewData_->chainRow_ = saveRow_;
+    viewData_->chainCol_ = saveCol_;
+
+    View::SetNotification("copied selection");
+};
 
 /******************************************************
  cut:  copies data in the current selection to the
        clipboard, clear selection content & end selection
        process
  ******************************************************/
- 
+
 void ChainView::cutSelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
 
-//	saveClipboardPosition() ;
+    //	saveClipboardPosition() ;
 
-    fillClipboardData() ;
-    
-// Loop over selection col, row & clear data inside it
+    fillClipboardData();
 
-    unsigned char *dst1=viewData_->song_->chain_->data_+16*viewData_->currentChain_ ;
-    unsigned char *dst2=viewData_->song_->chain_->transpose_+16*viewData_->currentChain_ ;
+    // Loop over selection col, row & clear data inside it
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<clipboard_.height_;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                    dst1[j+clipboard_.row_]=0xFF ;
-                    break ;
-                case 1:
-                    dst2[j+clipboard_.row_]=00 ;
-                    break ;
+    unsigned char *dst1 =
+        viewData_->song_->chain_->data_ + 16 * viewData_->currentChain_;
+    unsigned char *dst2 =
+        viewData_->song_->chain_->transpose_ + 16 * viewData_->currentChain_;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < clipboard_.height_; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+                dst1[j + clipboard_.row_] = 0xFF;
+                break;
+            case 1:
+                dst2[j + clipboard_.row_] = 00;
+                break;
             }
         }
     }
-    
-// Clear selection, end selection process & reposition cursor
 
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    viewData_->chainRow_=saveRow_ ; 
-    viewData_->chainCol_=saveCol_ ;
-    isDirty_=true ; 
-} ;
+    // Clear selection, end selection process & reposition cursor
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    viewData_->chainRow_ = saveRow_;
+    viewData_->chainCol_ = saveCol_;
+    isDirty_ = true;
+};
 
 /******************************************************
  pasteClipboard:
@@ -316,455 +322,493 @@ void ChainView::cutSelection() {
 
 void ChainView::pasteClipboard() {
 
- // Get number of row to paste
- 
-    int height=clipboard_.height_ ;
-    if (viewData_->chainRow_+height>16) {
-        height=16-viewData_->chainRow_ ;
-    }
-    
-    unsigned char *dst1=viewData_->song_->chain_->data_+16*viewData_->currentChain_ ;
-    unsigned char *src1=clipboard_.phrase_ ;
-    unsigned char *dst2=viewData_->song_->chain_->transpose_+16*viewData_->currentChain_ ;
-    unsigned char *src2=clipboard_.transpose_ ;   
+    // Get number of row to paste
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<height;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                    dst1[j+viewData_->chainRow_]=src1[j] ;
-                    break ;
-                case 1:
-                    dst2[j+viewData_->chainRow_]=src2[j] ;
-                    break ;
+    int height = clipboard_.height_;
+    if (viewData_->chainRow_ + height > 16) {
+        height = 16 - viewData_->chainRow_;
+    }
+
+    unsigned char *dst1 =
+        viewData_->song_->chain_->data_ + 16 * viewData_->currentChain_;
+    unsigned char *src1 = clipboard_.phrase_;
+    unsigned char *dst2 =
+        viewData_->song_->chain_->transpose_ + 16 * viewData_->currentChain_;
+    unsigned char *src2 = clipboard_.transpose_;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < height; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+                dst1[j + viewData_->chainRow_] = src1[j];
+                break;
+            case 1:
+                dst2[j + viewData_->chainRow_] = src2[j];
+                break;
             }
         }
     }
-	updateCursor(0x00,height) ;
-	isDirty_=true ;
-} ;
+    updateCursor(0x00, height);
+    isDirty_ = true;
+};
 
 void ChainView::unMuteAll() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->UnMuteAll() ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->UnMuteAll();
+};
 
 void ChainView::toggleMute() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->ToggleMute(viewData_->songX_,viewData_->songX_) ;
-	viewMode_=(viewMode_!=VM_MUTEON)?VM_MUTEON:VM_NORMAL ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->ToggleMute(viewData_->songX_, viewData_->songX_);
+    viewMode_ = (viewMode_ != VM_MUTEON) ? VM_MUTEON : VM_NORMAL;
+};
 
 void ChainView::switchSoloMode() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->SwitchSoloMode(viewData_->songX_,viewData_->songX_,(viewMode_==VM_NORMAL)) ;
-	viewMode_=(viewMode_!=VM_SOLOON)?VM_SOLOON:VM_NORMAL ;
-    isDirty_=true ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->SwitchSoloMode(viewData_->songX_, viewData_->songX_,
+                               (viewMode_ == VM_NORMAL));
+    viewMode_ = (viewMode_ != VM_SOLOON) ? VM_SOLOON : VM_NORMAL;
+    isDirty_ = true;
+};
 
-void ChainView::ProcessButtonMask(unsigned short mask,bool pressed) {
+void ChainView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
-	if (!pressed) {
-		if (viewMode_==VM_MUTEON) {
-			if (mask&EPBM_R) {
-				toggleMute() ;
-			}
-		} ;
-		if (viewMode_==VM_SOLOON) {
-			if (mask&EPBM_R) {
-				switchSoloMode() ;
-			}
-		} ;
-		return ;
-	} ;
-	
- 	if (viewMode_==VM_NEW) {
-		if (mask==EPBM_A) {
-			unsigned short next=viewData_->song_->phrase_->GetNext() ;
-			if (next!=NO_MORE_PHRASE) {
-				setPhrase((unsigned char)next) ;
-				isDirty_=true ;
-			}
-			mask&=(0xFFFF-EPBM_A) ;
-		}
-	}
-	
-	if (viewMode_==VM_CLONE) {
-        if ((mask&EPBM_A)&&(mask&EPBM_L)) {
-            clonePosition() ;
-            mask&=(0xFFFF-(EPBM_A|EPBM_L)) ;
+    if (!pressed) {
+        if (viewMode_ == VM_MUTEON) {
+            if (mask & EPBM_R) {
+                toggleMute();
+            }
+        };
+        if (viewMode_ == VM_SOLOON) {
+            if (mask & EPBM_R) {
+                switchSoloMode();
+            }
+        };
+        return;
+    };
+
+    if (viewMode_ == VM_NEW) {
+        if (mask == EPBM_A) {
+            unsigned short next = viewData_->song_->phrase_->GetNext();
+            if (next != NO_MORE_PHRASE) {
+                setPhrase((unsigned char)next);
+                isDirty_ = true;
+            }
+            mask &= (0xFFFF - EPBM_A);
+        }
+    }
+
+    if (viewMode_ == VM_CLONE) {
+        if ((mask & EPBM_A) && (mask & EPBM_L)) {
+            clonePosition();
+            mask &= (0xFFFF - (EPBM_A | EPBM_L));
         } else {
-            viewMode_=VM_SELECTION ;
+            viewMode_ = VM_SELECTION;
         }
-    } ;
-        
-	// Process selection related keys
-	
-	if (viewMode_==VM_SELECTION) {
-        
-        if (clipboard_.active_==false) {
-            clipboard_.active_=true ;
-            clipboard_.col_=viewData_->chainCol_ ;
-            clipboard_.row_=viewData_->chainRow_ ;
-			saveCol_=viewData_->chainCol_ ;
-			saveRow_=viewData_->chainRow_;
-        }
-        processSelectionButtonMask(mask) ;
-    } else {
-	   
-       // Switch back to normal mode
+    };
 
-        viewMode_=VM_NORMAL ;
-        processNormalButtonMask(mask) ;
+    // Process selection related keys
+
+    if (viewMode_ == VM_SELECTION) {
+
+        if (clipboard_.active_ == false) {
+            clipboard_.active_ = true;
+            clipboard_.col_ = viewData_->chainCol_;
+            clipboard_.row_ = viewData_->chainRow_;
+            saveCol_ = viewData_->chainCol_;
+            saveRow_ = viewData_->chainRow_;
+        }
+        processSelectionButtonMask(mask);
+    } else {
+
+        // Switch back to normal mode
+
+        viewMode_ = VM_NORMAL;
+        processNormalButtonMask(mask);
     }
 }
 
 void ChainView::processNormalButtonMask(unsigned short mask) {
-    
-    
-	Player *player=Player::GetInstance() ;
+
+    Player *player = Player::GetInstance();
 
     // B Modifier
-    
-	if (mask&EPBM_B) {
-		if (mask&EPBM_LEFT) warpToNeighbour(-1) ;
-		if (mask&EPBM_RIGHT) warpToNeighbour(+1);
-		if (mask&EPBM_UP) warpInColumn(-1) ;
-		if (mask&EPBM_DOWN) warpInColumn(+1);
-		if (mask&EPBM_A) cutPosition();
-        if (mask&EPBM_L) {
-            viewMode_=VM_CLONE ;
-        } ;
- 	    if (mask&EPBM_R) toggleMute() ;
-	} else {
-        
-      // A Modifier
-      
-	  if (mask&EPBM_A) {
-		  if (mask&EPBM_DOWN) updateCursorValue(viewData_->chainCol_==0?-0x10:-0x0C) ;
-		  if (mask&EPBM_UP) updateCursorValue(viewData_->chainCol_==0?0x10:0x0C) ;
-		  if (mask&EPBM_LEFT) updateCursorValue(-0x01) ;
-		  if (mask&EPBM_RIGHT) updateCursorValue(0x01) ;
-		  if (mask&EPBM_L) pasteClipboard() ;
-		  if (mask==EPBM_A) {
-              pasteLastPhrase() ;
-			  if (viewData_->chainCol_==0) viewMode_=VM_NEW ;
-		  }
-		  if (mask&EPBM_R) switchSoloMode() ;
-	  } else {
-            
-        // R Modifier
-            
-          if (mask&EPBM_R) {
-                
-			if (mask&EPBM_LEFT) {
-				ViewType vt=VT_SONG;
- 				ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-				SetChanged();
-				NotifyObservers(&ve) ;
-			}
-			
-			if (mask&EPBM_RIGHT) {
-				unsigned char *data=viewData_->GetCurrentChainPointer() ;
-				if (*data!=0xFF) {
-					ViewType vt=VT_PHRASE;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					viewData_->currentPhrase_=*data ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-			}
-			
-			// We toggle full chain start only if we"re not in live mode
-			// or if the player ain't playing yet
 
-			if (mask&EPBM_START) {
-				player->OnStartButton(PM_CHAIN,viewData_->songX_,true,viewData_->chainRow_) ;
-		    }
-			if (mask&EPBM_L) unMuteAll() ;
-	      } else {
-            // L Modifier
-            if (mask&EPBM_L) {
+    if (mask & EPBM_B) {
+        if (mask & EPBM_LEFT)
+            warpToNeighbour(-1);
+        if (mask & EPBM_RIGHT)
+            warpToNeighbour(+1);
+        if (mask & EPBM_UP)
+            warpInColumn(-1);
+        if (mask & EPBM_DOWN)
+            warpInColumn(+1);
+        if (mask & EPBM_A)
+            cutPosition();
+        if (mask & EPBM_L) {
+            viewMode_ = VM_CLONE;
+        };
+        if (mask & EPBM_R)
+            toggleMute();
+    } else {
 
-            } else {
-                // NO modifier
-			   if (mask&EPBM_DOWN) updateCursor(0,1) ;
-			   if (mask&EPBM_UP) updateCursor(0,-1) ;
-			   if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-			   if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-			   if (mask&EPBM_START) {
-					player->OnStartButton(PM_CHAIN,viewData_->songX_,false,viewData_->chainRow_) ;
-			   }
+        // A Modifier
+
+        if (mask & EPBM_A) {
+            if (mask & EPBM_DOWN)
+                updateCursorValue(viewData_->chainCol_ == 0 ? -0x10 : -0x0C);
+            if (mask & EPBM_UP)
+                updateCursorValue(viewData_->chainCol_ == 0 ? 0x10 : 0x0C);
+            if (mask & EPBM_LEFT)
+                updateCursorValue(-0x01);
+            if (mask & EPBM_RIGHT)
+                updateCursorValue(0x01);
+            if (mask & EPBM_L)
+                pasteClipboard();
+            if (mask == EPBM_A) {
+                pasteLastPhrase();
+                if (viewData_->chainCol_ == 0)
+                    viewMode_ = VM_NEW;
             }
-            
-          }
-	  } 
-	    
-	}
-	if ((!(mask&EPBM_A))&&updatingPhrase_) {
-		unsigned char *c=viewData_->song_->chain_->data_+(16*viewData_->currentChain_+updateRow_) ;
-		viewData_->song_->phrase_->SetUsed(*c) ;
-		updatingPhrase_=false ;
-	}
-} ;
+            if (mask & EPBM_R)
+                switchSoloMode();
+        } else {
+
+            // R Modifier
+
+            if (mask & EPBM_R) {
+
+                if (mask & EPBM_LEFT) {
+                    ViewType vt = VT_SONG;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+
+                if (mask & EPBM_RIGHT) {
+                    unsigned char *data = viewData_->GetCurrentChainPointer();
+                    if (*data != 0xFF) {
+                        ViewType vt = VT_PHRASE;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        viewData_->currentPhrase_ = *data;
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
+
+                // We toggle full chain start only if we"re not in live mode
+                // or if the player ain't playing yet
+
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_CHAIN, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
+                if (mask & EPBM_L)
+                    unMuteAll();
+            } else {
+                // L Modifier
+                if (mask & EPBM_L) {
+
+                } else {
+                    // NO modifier
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+                    if (mask & EPBM_START) {
+                        player->OnStartButton(PM_CHAIN, viewData_->songX_,
+                                              false, viewData_->chainRow_);
+                    }
+                }
+            }
+        }
+    }
+    if ((!(mask & EPBM_A)) && updatingPhrase_) {
+        unsigned char *c = viewData_->song_->chain_->data_ +
+                           (16 * viewData_->currentChain_ + updateRow_);
+        viewData_->song_->phrase_->SetUsed(*c);
+        updatingPhrase_ = false;
+    }
+};
 
 void ChainView::processSelectionButtonMask(unsigned short mask) {
 
-	Player *player=Player::GetInstance() ;
+    Player *player = Player::GetInstance();
 
-	// B Modifier
+    // B Modifier
 
-	if (mask&EPBM_B) {
-		if (mask==EPBM_B) copySelection() ;
- 	    if (mask&EPBM_R) toggleMute() ;
-		if (mask&EPBM_L) extendSelection() ;
+    if (mask & EPBM_B) {
+        if (mask == EPBM_B)
+            copySelection();
+        if (mask & EPBM_R)
+            toggleMute();
+        if (mask & EPBM_L)
+            extendSelection();
     } else {
 
-	  // A modifier
+        // A modifier
 
-	  if (mask&EPBM_A) {
+        if (mask & EPBM_A) {
 
-		  if (mask&EPBM_DOWN) updateSelectionValue(viewData_->chainCol_==0?-0x10:-0x0C) ;
-		  if (mask&EPBM_UP) updateSelectionValue(viewData_->chainCol_==0?0x10:0x0C) ;
-		  if (mask&EPBM_LEFT) updateSelectionValue(-0x01) ;
-		  if (mask&EPBM_RIGHT) updateSelectionValue(0x01) ;
+            if (mask & EPBM_DOWN)
+                updateSelectionValue(viewData_->chainCol_ == 0 ? -0x10 : -0x0C);
+            if (mask & EPBM_UP)
+                updateSelectionValue(viewData_->chainCol_ == 0 ? 0x10 : 0x0C);
+            if (mask & EPBM_LEFT)
+                updateSelectionValue(-0x01);
+            if (mask & EPBM_RIGHT)
+                updateSelectionValue(0x01);
 
-            if (mask&EPBM_L) {
-                cutSelection() ;
+            if (mask & EPBM_L) {
+                cutSelection();
             }
-			if (mask&EPBM_R) switchSoloMode() ;
-	  } else {
+            if (mask & EPBM_R)
+                switchSoloMode();
+        } else {
 
-		  // R Modifier
+            // R Modifier
 
-        if (mask&EPBM_R) {
-                
-			if (mask&EPBM_LEFT) {
-				ViewType vt=VT_SONG;
- 				ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-				SetChanged();
-				NotifyObservers(&ve) ;
-			}
-			
-			if (mask&EPBM_RIGHT) {
-				unsigned char *data=viewData_->GetCurrentChainPointer() ;
-				if (*data!=0xFF) {
-					ViewType vt=VT_PHRASE;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					viewData_->currentPhrase_=*data ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-			}
-			
-			if (mask&EPBM_START) {
-					player->OnStartButton(PM_CHAIN,viewData_->songX_,true,viewData_->chainRow_) ;
-		    }
+            if (mask & EPBM_R) {
 
-			if (mask&EPBM_L) unMuteAll() ;
+                if (mask & EPBM_LEFT) {
+                    ViewType vt = VT_SONG;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
 
-	    } else {
+                if (mask & EPBM_RIGHT) {
+                    unsigned char *data = viewData_->GetCurrentChainPointer();
+                    if (*data != 0xFF) {
+                        ViewType vt = VT_PHRASE;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        viewData_->currentPhrase_ = *data;
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
 
-    			// No modifier
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_CHAIN, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
 
-    		if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    		if (mask&EPBM_UP) updateCursor(0,-1) ;
-    	   	if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    		if (mask&EPBM_RIGHT) updateCursor(1,0) ;
+                if (mask & EPBM_L)
+                    unMuteAll();
 
-			if (mask&EPBM_START) {
-				player->OnStartButton(PM_CHAIN,viewData_->songX_,false,viewData_->chainRow_) ;
-			}
-		}
-	  } 
-	}
-} ;
+            } else {
 
-void ChainView::OnFocus() {
-    clipboard_.active_=false ;
-} ;
+                // No modifier
 
-void ChainView::setTextProps(GUITextProperties &props,int row,int col,bool restore) {
+                if (mask & EPBM_DOWN)
+                    updateCursor(0, 1);
+                if (mask & EPBM_UP)
+                    updateCursor(0, -1);
+                if (mask & EPBM_LEFT)
+                    updateCursor(-1, 0);
+                if (mask & EPBM_RIGHT)
+                    updateCursor(1, 0);
 
-	bool invert=false ;
-	
-	if (clipboard_.active_) {
-        GUIRect selRect=getSelectionRect() ;
-        if ((row>=selRect.Left())&&(row<=selRect.Right())&&
-            (col>=selRect.Top())&&(col<=selRect.Bottom())) {
-                invert=true ;
-        }        
-    } else {
-    	if ((viewData_->chainCol_==row)&&(viewData_->chainRow_==col)) {
-            invert=true ;
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_CHAIN, viewData_->songX_, false,
+                                          viewData_->chainRow_);
+                }
+            }
         }
     }
-    
+};
+
+void ChainView::OnFocus() { clipboard_.active_ = false; };
+
+void ChainView::setTextProps(GUITextProperties &props, int row, int col,
+                             bool restore) {
+
+    bool invert = false;
+
+    if (clipboard_.active_) {
+        GUIRect selRect = getSelectionRect();
+        if ((row >= selRect.Left()) && (row <= selRect.Right()) &&
+            (col >= selRect.Top()) && (col <= selRect.Bottom())) {
+            invert = true;
+        }
+    } else {
+        if ((viewData_->chainCol_ == row) && (viewData_->chainRow_ == col)) {
+            invert = true;
+        }
+    }
+
     if (invert) {
         if (restore) {
-    		SetColor(CD_NORMAL) ;
-	   	    props.invert_=false;
+            SetColor(CD_NORMAL);
+            props.invert_ = false;
         } else {
-    		SetColor(CD_HILITE2) ;
-	   	    props.invert_=true;            
+            SetColor(CD_HILITE2);
+            props.invert_ = true;
         }
-	}
-} ;
+    }
+};
 
 void ChainView::DrawView() {
 
-	Clear() ;
-	View::EnableNotification();
+    Clear();
+    View::EnableNotification();
 
-	GUITextProperties props ;
-	GUIPoint pos=GetTitlePosition() ;
+    GUITextProperties props;
+    GUIPoint pos = GetTitlePosition();
 
-// Draw title
+    // Draw title
 
-	char title[20] ;
-	SetColor(CD_NORMAL) ;
-	sprintf(title,"Chain %2.2x",viewData_->currentChain_) ;
-	DrawString(pos._x,pos._y,title,props) ;
+    char title[20];
+    SetColor(CD_NORMAL);
+    sprintf(title, "Chain %2.2x", viewData_->currentChain_);
+    DrawString(pos._x, pos._y, title, props);
 
-// Compute song grid location
+    // Compute song grid location
 
-	GUIPoint anchor=GetAnchor();
-	
-// Display row numbers
+    GUIPoint anchor = GetAnchor();
 
-	char row[3] ;
-	pos=anchor ;
-	pos._x-=3 ;
-	for (int j=0;j<16;j++) {
-		((j/altRowNumber_)%2)?SetColor(CD_ROW):SetColor(CD_ROW2);
-		hex2char(j,row) ;
-		DrawString(pos._x,pos._y,row,props) ;
-		pos._y+=1 ;
-	}
+    // Display row numbers
 
-	SetColor(CD_NORMAL) ;
+    char row[3];
+    pos = anchor;
+    pos._x -= 3;
+    for (int j = 0; j < 16; j++) {
+        ((j / altRowNumber_) % 2) ? SetColor(CD_ROW) : SetColor(CD_ROW2);
+        hex2char(j, row);
+        DrawString(pos._x, pos._y, row, props);
+        pos._y += 1;
+    }
 
-	pos=anchor ;
+    SetColor(CD_NORMAL);
 
-// Display phrases
+    pos = anchor;
 
-	pos=anchor ;
+    // Display phrases
 
-	unsigned char *data=viewData_->song_->chain_->data_+(16*viewData_->currentChain_) ;
+    pos = anchor;
 
-	for (int j=0;j<16;j++) {
-		unsigned char d=*data++ ;
-        setTextProps(props,0,j,false) ;
-		if (d==0xFF) {
-			DrawString(pos._x,pos._y,"--",props) ;
-		} else {
-			hex2char(d,row) ;
-			DrawString(pos._x,pos._y,row,props) ;
-		}
-        setTextProps(props,0,j,true) ;		
-		pos._y++ ;
-	}
+    unsigned char *data =
+        viewData_->song_->chain_->data_ + (16 * viewData_->currentChain_);
 
-// Draw Transpose
-
-	pos=anchor ;
-	pos._x+=3;
-
-	data=viewData_->song_->chain_->transpose_+(16*viewData_->currentChain_) ;
-
-	for (int j=0;j<16;j++) {
-		unsigned char d=*data++ ;
-		hex2char(d,row) ;
-        setTextProps(props,1,j,false) ;
-		DrawString(pos._x,pos._y,row,props) ;
-        setTextProps(props,1,j,true) ;
-		pos._y++ ;
-	}
-	Player *player=Player::GetInstance() ;
-	
-	drawMap() ;
-	drawNotes() ;
-	
-	if (player->IsRunning()) {
-		OnPlayerUpdate(PET_UPDATE) ;
-	} ;
-
-} ;
-
-void ChainView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
-
-	Player *player=Player::GetInstance() ;
-
-    drawNotes() ;
-    
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint pos=anchor ;
-	pos._x-=1 ;
-
-	GUITextProperties props ;
-	SetColor(CD_NORMAL) ;
-
-	// Clear last played & queued
-
-	pos._y=anchor._y+lastPlayingPos_ ;
-	DrawString(pos._x,pos._y," ",props) ;
-
-	pos._y=anchor._y+lastQueuedPos_ ;
-	DrawString(pos._x,pos._y," ",props) ;
-
-	if (eventType!=PET_STOP) {
-
-	// Loop on all channels to see if one of them is playing current chain
-
-		for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
-            if (player->IsChannelPlaying(i)) {
-    			if (viewData_->currentPlayChain_[i]==viewData_->currentChain_ &&
-		            viewData_->playMode_ != PM_AUDITION) {
-    				pos._y=anchor._y+viewData_->chainPlayPos_[i] ;
-    				if (!player->IsChannelMuted(i)) {
-						SetColor(CD_PLAY);
-						DrawString(pos._x,pos._y,">",props);
-    					SetColor(CD_NORMAL);
-    				} else {
-                        SetColor(CD_MUTE);
-						DrawString(pos._x,pos._y,"-",props);
-						SetColor(CD_NORMAL);
-    				}
-    				lastPlayingPos_=viewData_->chainPlayPos_[i] ;
-    				break ;
-    			}
-    		}
+    for (int j = 0; j < 16; j++) {
+        unsigned char d = *data++;
+        setTextProps(props, 0, j, false);
+        if (d == 0xFF) {
+            DrawString(pos._x, pos._y, "--", props);
+        } else {
+            hex2char(d, row);
+            DrawString(pos._x, pos._y, row, props);
         }
-        
-		// Loop on all channels to see if one has queued current chain
+        setTextProps(props, 0, j, true);
+        pos._y++;
+    }
 
-		if (player->GetSequencerMode()==SM_LIVE) {
+    // Draw Transpose
 
-			for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
-			   // is anything queued ?
-			   if (player->GetQueueingMode(i)!=QM_NONE) {
-				   // find the chain queued in channel
-					unsigned char songPos=player->GetQueuePosition(i) ;
-					unsigned char *chain=viewData_->song_->data_+i+8*songPos ;
-					if (*chain==viewData_->currentChain_) {
-						unsigned char chainPos=player->GetQueueChainPosition(i) ;
-						pos._y=anchor._y+chainPos ;
-						char *indicator=player->GetLiveIndicator(i) ;
-						DrawString(pos._x,pos._y,indicator,props) ;
-						lastQueuedPos_=chainPos ;
-						break ;
-					}
-			   }
-			}
+    pos = anchor;
+    pos._x += 3;
 
-		}
-	}
-	
-    pos=anchor ;
-    pos._x+=200 ;
+    data =
+        viewData_->song_->chain_->transpose_ + (16 * viewData_->currentChain_);
+
+    for (int j = 0; j < 16; j++) {
+        unsigned char d = *data++;
+        hex2char(d, row);
+        setTextProps(props, 1, j, false);
+        DrawString(pos._x, pos._y, row, props);
+        setTextProps(props, 1, j, true);
+        pos._y++;
+    }
+    Player *player = Player::GetInstance();
+
+    drawMap();
+    drawNotes();
+
+    if (player->IsRunning()) {
+        OnPlayerUpdate(PET_UPDATE);
+    };
+};
+
+void ChainView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
+
+    Player *player = Player::GetInstance();
+
+    drawNotes();
+
+    GUIPoint anchor = GetAnchor();
+    GUIPoint pos = anchor;
+    pos._x -= 1;
+
+    GUITextProperties props;
+    SetColor(CD_NORMAL);
+
+    // Clear last played & queued
+
+    pos._y = anchor._y + lastPlayingPos_;
+    DrawString(pos._x, pos._y, " ", props);
+
+    pos._y = anchor._y + lastQueuedPos_;
+    DrawString(pos._x, pos._y, " ", props);
+
+    if (eventType != PET_STOP) {
+
+        // Loop on all channels to see if one of them is playing current chain
+
+        for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+            if (player->IsChannelPlaying(i)) {
+                if (viewData_->currentPlayChain_[i] ==
+                        viewData_->currentChain_ &&
+                    viewData_->playMode_ != PM_AUDITION) {
+                    pos._y = anchor._y + viewData_->chainPlayPos_[i];
+                    if (!player->IsChannelMuted(i)) {
+                        SetColor(CD_PLAY);
+                        DrawString(pos._x, pos._y, ">", props);
+                        SetColor(CD_NORMAL);
+                    } else {
+                        SetColor(CD_MUTE);
+                        DrawString(pos._x, pos._y, "-", props);
+                        SetColor(CD_NORMAL);
+                    }
+                    lastPlayingPos_ = viewData_->chainPlayPos_[i];
+                    break;
+                }
+            }
+        }
+
+        // Loop on all channels to see if one has queued current chain
+
+        if (player->GetSequencerMode() == SM_LIVE) {
+
+            for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+                // is anything queued ?
+                if (player->GetQueueingMode(i) != QM_NONE) {
+                    // find the chain queued in channel
+                    unsigned char songPos = player->GetQueuePosition(i);
+                    unsigned char *chain =
+                        viewData_->song_->data_ + i + 8 * songPos;
+                    if (*chain == viewData_->currentChain_) {
+                        unsigned char chainPos =
+                            player->GetQueueChainPosition(i);
+                        pos._y = anchor._y + chainPos;
+                        char *indicator = player->GetLiveIndicator(i);
+                        DrawString(pos._x, pos._y, indicator, props);
+                        lastQueuedPos_ = chainPos;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    pos = anchor;
+    pos._x += 200;
 /*
 	if (player->Clipped()) {
            w_.DrawString("clip",pos,props); 

--- a/sources/Application/Views/ChainView.h
+++ b/sources/Application/Views/ChainView.h
@@ -5,62 +5,63 @@
 #include "BaseClasses/View.h"
 #include "ViewData.h"
 
-class ChainView: public View {
-public:
-	ChainView(GUIWindow &w,ViewData *data) ;
-	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
-	virtual void DrawView() ;
-	virtual void OnFocus()  ;
-	virtual void OnPlayerUpdate(PlayerEventType,unsigned int tick=0) ;
-protected:
-	void updateCursor(int dx,int dy) ;
-	void updateCursorValue(int offset,int dx=0,int dy=0) ;
-	void updateSelectionValue(int offset) ;
-	void setPhrase(unsigned char value) ;
-	void warpToNeighbour(int offset) ;
-	void warpInColumn(int offset) ;
-	void cutPosition() ;
-	void clonePosition() ;
-	void pasteLastPhrase() ;
-	void extendSelection(); 
+class ChainView : public View {
+  public:
+    ChainView(GUIWindow &w, ViewData *data);
+    virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+    virtual void DrawView();
+    virtual void OnFocus();
+    virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
 
-	GUIRect getSelectionRect() ;
-	void fillClipboardData() ;
-	void copySelection() ;
-	void cutSelection() ;
-	void pasteClipboard() ;
-    	
-	void unMuteAll() ;
-	void toggleMute() ;
-	void switchSoloMode() ;
+  protected:
+    void updateCursor(int dx, int dy);
+    void updateCursorValue(int offset, int dx = 0, int dy = 0);
+    void updateSelectionValue(int offset);
+    void setPhrase(unsigned char value);
+    void warpToNeighbour(int offset);
+    void warpInColumn(int offset);
+    void cutPosition();
+    void clonePosition();
+    void pasteLastPhrase();
+    void extendSelection();
 
-	void processNormalButtonMask(unsigned short mask) ;
-	void processSelectionButtonMask(unsigned short mask) ;
-    void setTextProps(GUITextProperties & props, int row,int col,bool restore) ;
+    GUIRect getSelectionRect();
+    void fillClipboardData();
+    void copySelection();
+    void cutSelection();
+    void pasteClipboard();
 
-private:
-	bool updatingPhrase_ ;		// .Tells if we're in the middle
-                                    //  of updating a phrase to avoid
-                                    //  allocation of unused phrases
-	int updateRow_ ;			// .Tells which row is being updated
-	unsigned char lastPhrase_ ;   // .Clipboard for phrase
-	int lastPlayingPos_ ;
-	int lastQueuedPos_ ;
-	
-	struct ChainClip {
-        bool active_ ;
-        int col_ ;
-        int row_ ;
-        int width_ ;
-        int height_ ;
-//		int saverow_ ;
-//		int savecol_ ;
-        unsigned char phrase_[16] ;
-        unsigned char transpose_[16] ;
-    } clipboard_ ;
+    void unMuteAll();
+    void toggleMute();
+    void switchSoloMode();
 
-	int saveRow_ ;
-	int saveCol_ ;
-} ;
+    void processNormalButtonMask(unsigned short mask);
+    void processSelectionButtonMask(unsigned short mask);
+    void setTextProps(GUITextProperties &props, int row, int col, bool restore);
+
+  private:
+    bool updatingPhrase_;      // .Tells if we're in the middle
+                               //  of updating a phrase to avoid
+                               //  allocation of unused phrases
+    int updateRow_;            // .Tells which row is being updated
+    unsigned char lastPhrase_; // .Clipboard for phrase
+    int lastPlayingPos_;
+    int lastQueuedPos_;
+
+    struct ChainClip {
+        bool active_;
+        int col_;
+        int row_;
+        int width_;
+        int height_;
+        //		int saverow_ ;
+        //		int savecol_ ;
+        unsigned char phrase_[16];
+        unsigned char transpose_[16];
+    } clipboard_;
+
+    int saveRow_;
+    int saveCol_;
+};
 
 #endif

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -203,8 +203,9 @@ void GrooveView::OnPlayerUpdate(PlayerEventType ,unsigned int tick) {
 		lastPosition_=groovepos ;
 		pos._x=anchor._x-1 ;
 		pos._y=anchor._y+lastPosition_ ;
-		SetColor(CD_CURSOR) ;
-		DrawString(pos._x,pos._y,">",props) ;
+        SetColor(CD_PLAY);
+        DrawString(pos._x,pos._y,">",props);
+        SetColor(CD_NORMAL);
 	} ;
 
     drawNotes() ;

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1,389 +1,392 @@
 #include "PhraseView.h"
-#include "System/Console/Trace.h"
-#include "Application/Utils/char.h"
 #include "Application/Instruments/CommandList.h"
-#include "UIController.h"
 #include "Application/Model/Table.h"
 #include "Application/Utils/HelpLegend.h"
-#include <string.h>
+#include "Application/Utils/char.h"
+#include "System/Console/Trace.h"
+#include "UIController.h"
 #include <stdlib.h>
- 
-short PhraseView::offsets_[2][4] = {
-	-1,1,12,-12,
-	-1,1,16,-16
-} ;
+#include <string.h>
 
-PhraseView::PhraseView(GUIWindow &w,ViewData *viewData):
-           View(w,viewData),
-		   cmdEdit_("edit",FCC_EDIT,0)
- {
-	phrase_=viewData_->song_->phrase_ ;
-	lastPlayingPos_=0 ;
-	GUIPoint pos(0,10) ;
-	cmdEditField_=new UIBigHexVarField(pos,cmdEdit_,4,"%4.4X",0,0xFFFF,16,true) ;
-	row_=0 ;
-	viewData->phraseCurPos_ = 0;
-	col_=0 ;
-	lastNote_=60 ;
-	lastInstr_=0 ;
-	lastCmd_=I_CMD_NONE ;
-	lastParam_=0 ;
-	
-	clipboard_.active_=false ;
-	clipboard_.width_=0 ;
-	clipboard_.height_=0 ;
+short PhraseView::offsets_[2][4] = {-1, 1, 12, -12, -1, 1, 16, -16};
 
-	for (int i=0;i<16;i++) {
-		clipboard_.note_[i]=0xFF ;
-		clipboard_.instr_[i]=0 ;
-	} ;
-	View::EnableNotification();
+PhraseView::PhraseView(GUIWindow &w, ViewData *viewData)
+    : View(w, viewData), cmdEdit_("edit", FCC_EDIT, 0) {
+    phrase_ = viewData_->song_->phrase_;
+    lastPlayingPos_ = 0;
+    GUIPoint pos(0, 10);
+    cmdEditField_ =
+        new UIBigHexVarField(pos, cmdEdit_, 4, "%4.4X", 0, 0xFFFF, 16, true);
+    row_ = 0;
+    viewData->phraseCurPos_ = 0;
+    col_ = 0;
+    lastNote_ = 60;
+    lastInstr_ = 0;
+    lastCmd_ = I_CMD_NONE;
+    lastParam_ = 0;
+
+    clipboard_.active_ = false;
+    clipboard_.width_ = 0;
+    clipboard_.height_ = 0;
+
+    for (int i = 0; i < 16; i++) {
+        clipboard_.note_[i] = 0xFF;
+        clipboard_.instr_[i] = 0;
+    };
+    View::EnableNotification();
 }
 
-PhraseView::~PhraseView() {
-	delete cmdEditField_ ;
-};
+PhraseView::~PhraseView() { delete cmdEditField_; };
 
-void PhraseView::updateCursor(int dx,int dy) {
+void PhraseView::updateCursor(int dx, int dy) {
 
-	col_+=dx ;
-	row_+=dy ;
-	if (col_>5) col_=5 ;
-	if (col_<0) col_=0 ;
-	if (row_>15) {
-		// Try to see if the current chain has a phrase after this one
-		
-		if ((viewMode_!=VM_SELECTION)&&(viewData_->chainRow_<15)) {
-			viewData_->chainRow_++ ;
-			unsigned char *p=viewData_->GetCurrentChainPointer() ;
-			if (*p!=0xFF) {
-				viewData_->currentPhrase_=*p ;
-				row_=0 ;
-			} else { // rollback
-				viewData_->chainRow_-- ;
-				row_=15 ;
-			}			
-		} else {
-			row_=15 ;
-		}
-	}
-	if (row_<0) {
+    col_ += dx;
+    row_ += dy;
+    if (col_ > 5)
+        col_ = 5;
+    if (col_ < 0)
+        col_ = 0;
+    if (row_ > 15) {
+        // Try to see if the current chain has a phrase after this one
 
-		// Try to see if the current chain has a phrase before this one
-		
-		if ((viewMode_!=VM_SELECTION)&&(viewData_->chainRow_>0)) {
-			viewData_->chainRow_-- ;
-			unsigned char *p=viewData_->GetCurrentChainPointer() ;
-			if (*p!=0xFF) {
-				viewData_->currentPhrase_=*p ;
-				row_=15 ;
-			} else { // rollback
-				viewData_->chainRow_++ ;
-				row_=0 ;
-			}			
-		} else {
-			row_=0  ;
-		}
-	}
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint p(anchor) ;
-	switch(col_) {
-		case 3:
-			p._x+=13 ;
-			p._y+=row_ ;
-			cmdEditField_->SetPosition(p) ;
-			cmdEdit_.SetInt(*(phrase_->param1_+(16*viewData_->currentPhrase_+row_))) ;
-			break ;
-		case 5:
-			p._x+=23 ;
-			p._y+=row_ ;
-			cmdEditField_->SetPosition(p) ;
-			cmdEdit_.SetInt(*(phrase_->param2_+(16*viewData_->currentPhrase_+row_))) ;
-			break ;
-	} ;
-	viewData_->phraseCurPos_ = row_;
-	isDirty_=true;
+        if ((viewMode_ != VM_SELECTION) && (viewData_->chainRow_ < 15)) {
+            viewData_->chainRow_++;
+            unsigned char *p = viewData_->GetCurrentChainPointer();
+            if (*p != 0xFF) {
+                viewData_->currentPhrase_ = *p;
+                row_ = 0;
+            } else { // rollback
+                viewData_->chainRow_--;
+                row_ = 15;
+            }
+        } else {
+            row_ = 15;
+        }
+    }
+    if (row_ < 0) {
+
+        // Try to see if the current chain has a phrase before this one
+
+        if ((viewMode_ != VM_SELECTION) && (viewData_->chainRow_ > 0)) {
+            viewData_->chainRow_--;
+            unsigned char *p = viewData_->GetCurrentChainPointer();
+            if (*p != 0xFF) {
+                viewData_->currentPhrase_ = *p;
+                row_ = 15;
+            } else { // rollback
+                viewData_->chainRow_++;
+                row_ = 0;
+            }
+        } else {
+            row_ = 0;
+        }
+    }
+    GUIPoint anchor = GetAnchor();
+    GUIPoint p(anchor);
+    switch (col_) {
+    case 3:
+        p._x += 13;
+        p._y += row_;
+        cmdEditField_->SetPosition(p);
+        cmdEdit_.SetInt(
+            *(phrase_->param1_ + (16 * viewData_->currentPhrase_ + row_)));
+        break;
+    case 5:
+        p._x += 23;
+        p._y += row_;
+        cmdEditField_->SetPosition(p);
+        cmdEdit_.SetInt(
+            *(phrase_->param2_ + (16 * viewData_->currentPhrase_ + row_)));
+        break;
+    };
+    viewData_->phraseCurPos_ = row_;
+    isDirty_ = true;
 }
 
 void PhraseView::stopAudition() {
-	Player *player = Player::GetInstance();
-	if (viewData_->playMode_ == PM_AUDITION)
-		player->Stop();
+    Player *player = Player::GetInstance();
+    if (viewData_->playMode_ == PM_AUDITION)
+        player->Stop();
 }
 
-void PhraseView::updateCursorValue(ViewUpdateDirection direction,int xOffset,int yOffset) {
+void PhraseView::updateCursorValue(ViewUpdateDirection direction, int xOffset,
+                                   int yOffset) {
 
-	unsigned char *c=0 ;
-	unsigned char limit=0 ;
-	bool wrap=false ;
-    FourCC *cc ;
-    
-    
-	switch (col_+xOffset) {
-		case 0:
-			c=phrase_->note_+(16*viewData_->currentPhrase_+row_+yOffset) ;
-			limit=119 ;
-			wrap=true ;
-			break ;
-		case 1:
-			c=phrase_->instr_+(16*viewData_->currentPhrase_+row_+yOffset) ;
-			limit=MAX_INSTRUMENT_COUNT-1 ;
-			wrap=true;
-			break ;
-		case 2:
-			cc=phrase_->cmd1_+(16*viewData_->currentPhrase_+row_+yOffset) ;
-			switch (direction) {
-				case VUD_RIGHT :
-					*cc=CommandList::GetNext(*cc) ;
-					break ;
-				case VUD_UP:
-					*cc=CommandList::GetNextAlpha(*cc) ;
-					break ;
-				case VUD_LEFT :
-					*cc=CommandList::GetPrev(*cc) ;
-					break ;
-				case VUD_DOWN:
-					*cc=CommandList::GetPrevAlpha(*cc) ;
-					break ;
-			}
-			lastCmd_=*cc ;
-			//Set legend
-			break ;
+    unsigned char *c = 0;
+    unsigned char limit = 0;
+    bool wrap = false;
+    FourCC *cc;
 
-		case 3:
-			switch(direction) {
-				case VUD_RIGHT:
-					cmdEditField_->ProcessArrow(EPBM_RIGHT) ;
-					break ;
-				case VUD_UP:
-					cmdEditField_->ProcessArrow(EPBM_UP) ;
-					break ;
-				case VUD_LEFT:
-					cmdEditField_->ProcessArrow(EPBM_LEFT) ;
-					break ;
-				case VUD_DOWN:
-					cmdEditField_->ProcessArrow(EPBM_DOWN) ;
-					break ;
-			}
-			*(phrase_->param1_+(16*viewData_->currentPhrase_+row_+yOffset))=cmdEdit_.GetInt() ;
-			lastParam_=cmdEdit_.GetInt() ;
-			break;
-		case 4:
-			cc=phrase_->cmd2_+(16*viewData_->currentPhrase_+row_+yOffset) ;
-			switch (direction) {
-				case VUD_RIGHT :
-					*cc=CommandList::GetNext(*cc) ;
-					break ;
-				case VUD_UP:
-					*cc=CommandList::GetNextAlpha(*cc) ;
-					break ;
-				case VUD_LEFT :
-					*cc=CommandList::GetPrev(*cc) ;
-					break ;
-				case VUD_DOWN:
-					*cc=CommandList::GetPrevAlpha(*cc) ;
-					break ;
-			}
-			lastCmd_=*cc ;
-			break ;
-		case 5:
-			switch(direction) {
-				case VUD_RIGHT:
-					cmdEditField_->ProcessArrow(EPBM_RIGHT) ;
-					break ;
-				case VUD_UP:
-					cmdEditField_->ProcessArrow(EPBM_UP) ;
-					break ;
-				case VUD_LEFT:
-					cmdEditField_->ProcessArrow(EPBM_LEFT) ;
-					break ;
-				case VUD_DOWN:
-					cmdEditField_->ProcessArrow(EPBM_DOWN) ;
-					break ;
-			}
-			*(phrase_->param2_+(16*viewData_->currentPhrase_+row_+yOffset))=cmdEdit_.GetInt() ;
-			lastParam_=cmdEdit_.GetInt() ;
-			break;
-	}
-	if ((c)&&(*c!=0xFF)) {
-		int offset=offsets_[col_+xOffset][direction] ;
+    switch (col_ + xOffset) {
+    case 0:
+        c = phrase_->note_ + (16 * viewData_->currentPhrase_ + row_ + yOffset);
+        limit = 119;
+        wrap = true;
+        break;
+    case 1:
+        c = phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_ + yOffset);
+        limit = MAX_INSTRUMENT_COUNT - 1;
+        wrap = true;
+        break;
+    case 2:
+        cc = phrase_->cmd1_ + (16 * viewData_->currentPhrase_ + row_ + yOffset);
+        switch (direction) {
+        case VUD_RIGHT:
+            *cc = CommandList::GetNext(*cc);
+            break;
+        case VUD_UP:
+            *cc = CommandList::GetNextAlpha(*cc);
+            break;
+        case VUD_LEFT:
+            *cc = CommandList::GetPrev(*cc);
+            break;
+        case VUD_DOWN:
+            *cc = CommandList::GetPrevAlpha(*cc);
+            break;
+        }
+        lastCmd_ = *cc;
+        // Set legend
+        break;
 
-    updateData(c,offset,limit,wrap) ;
-		switch(col_+xOffset) {
-			case 0:
-				lastNote_=*c ;
-				break ;
-			case 1:
-				lastInstr_=*c ;
-				break ;
-		}
-	}
-	Player *player = Player::GetInstance();
-	// Phrase FX params are currently not applied to preview
-	if (col_ == 0 || col_ == 1) { // || col_ == 3 || col_ == 5) { 
-		if (player->IsRunning()) {
-			if ((viewData_->playMode_ == PM_AUDITION)) {
-				player->Stop();
-				player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
-										viewData_->chainRow_);
-			}
-		} else {
-			player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
-								viewData_->chainRow_);
-		}
-	}
-	isDirty_=true ;
+    case 3:
+        switch (direction) {
+        case VUD_RIGHT:
+            cmdEditField_->ProcessArrow(EPBM_RIGHT);
+            break;
+        case VUD_UP:
+            cmdEditField_->ProcessArrow(EPBM_UP);
+            break;
+        case VUD_LEFT:
+            cmdEditField_->ProcessArrow(EPBM_LEFT);
+            break;
+        case VUD_DOWN:
+            cmdEditField_->ProcessArrow(EPBM_DOWN);
+            break;
+        }
+        *(phrase_->param1_ + (16 * viewData_->currentPhrase_ + row_ +
+                              yOffset)) = cmdEdit_.GetInt();
+        lastParam_ = cmdEdit_.GetInt();
+        break;
+    case 4:
+        cc = phrase_->cmd2_ + (16 * viewData_->currentPhrase_ + row_ + yOffset);
+        switch (direction) {
+        case VUD_RIGHT:
+            *cc = CommandList::GetNext(*cc);
+            break;
+        case VUD_UP:
+            *cc = CommandList::GetNextAlpha(*cc);
+            break;
+        case VUD_LEFT:
+            *cc = CommandList::GetPrev(*cc);
+            break;
+        case VUD_DOWN:
+            *cc = CommandList::GetPrevAlpha(*cc);
+            break;
+        }
+        lastCmd_ = *cc;
+        break;
+    case 5:
+        switch (direction) {
+        case VUD_RIGHT:
+            cmdEditField_->ProcessArrow(EPBM_RIGHT);
+            break;
+        case VUD_UP:
+            cmdEditField_->ProcessArrow(EPBM_UP);
+            break;
+        case VUD_LEFT:
+            cmdEditField_->ProcessArrow(EPBM_LEFT);
+            break;
+        case VUD_DOWN:
+            cmdEditField_->ProcessArrow(EPBM_DOWN);
+            break;
+        }
+        *(phrase_->param2_ + (16 * viewData_->currentPhrase_ + row_ +
+                              yOffset)) = cmdEdit_.GetInt();
+        lastParam_ = cmdEdit_.GetInt();
+        break;
+    }
+    if ((c) && (*c != 0xFF)) {
+        int offset = offsets_[col_ + xOffset][direction];
+
+        updateData(c, offset, limit, wrap);
+        switch (col_ + xOffset) {
+        case 0:
+            lastNote_ = *c;
+            break;
+        case 1:
+            lastInstr_ = *c;
+            break;
+        }
+    }
+    Player *player = Player::GetInstance();
+    // Phrase FX params are currently not applied to preview
+    if (col_ == 0 || col_ == 1) { // || col_ == 3 || col_ == 5) {
+        if (player->IsRunning()) {
+            if ((viewData_->playMode_ == PM_AUDITION)) {
+                player->Stop();
+                player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                      viewData_->chainRow_);
+            }
+        } else {
+            player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                  viewData_->chainRow_);
+        }
+    }
+    isDirty_ = true;
 }
 
- // If we're on an empty spot, we past the last element
- // otherwise we take the current phrase as last
-
+// If we're on an empty spot, we past the last element
+// otherwise we take the current phrase as last
 
 void PhraseView::pasteLast() {
 
-	uchar  *c=0	 ;
-	uint   *i=0 ;
-	
-	switch (col_) {
-		case 0:
-			c=phrase_->note_+(16*viewData_->currentPhrase_+row_) ;
-			if ((*c==0xFF)) {
-				*c=lastNote_ ;
-				c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-				*c=lastInstr_ ;
-				isDirty_=true ;
-			} else {
-				lastNote_=*c ;
-				c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-				lastInstr_=*c ;
-			}
-			break ;
-		case 1:
-			c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-			if ((*c==0xFF)) {
-				*c=lastInstr_ ;
-				isDirty_=true ;
-			} else {
-				lastInstr_=*c ;
-			}
-			break ;
-		case 2:
-			i=phrase_->cmd1_+(16*viewData_->currentPhrase_+row_) ;
-			if (*i==I_CMD_NONE) {
-				*i=lastCmd_ ;
-				isDirty_=true ;
-			} else {
-				lastCmd_=*i ;
-			}
-			break ;
-			
-		case 3:
-/*			s=phrase_->param1_+(16*viewData_->currentPhrase_+row_) ;
-			if (*s==0) {
-				*s=lastParam_ ;
-				cmdEdit_.SetInt(lastParam_) ;
-				isDirty_=true ;
-			}
-�*/			break ;
+    uchar *c = 0;
+    uint *i = 0;
 
-		case 4:
-			i=phrase_->cmd2_+(16*viewData_->currentPhrase_+row_) ;
-			if (*i==I_CMD_NONE) {
-				*i=lastCmd_ ;
-				isDirty_=true ;
-			} else {
-				lastCmd_=*i ;
-			}
-			break ;
+    switch (col_) {
+    case 0:
+        c = phrase_->note_ + (16 * viewData_->currentPhrase_ + row_);
+        if ((*c == 0xFF)) {
+            *c = lastNote_;
+            c = phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
+            *c = lastInstr_;
+            isDirty_ = true;
+        } else {
+            lastNote_ = *c;
+            c = phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
+            lastInstr_ = *c;
+        }
+        break;
+    case 1:
+        c = phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
+        if ((*c == 0xFF)) {
+            *c = lastInstr_;
+            isDirty_ = true;
+        } else {
+            lastInstr_ = *c;
+        }
+        break;
+    case 2:
+        i = phrase_->cmd1_ + (16 * viewData_->currentPhrase_ + row_);
+        if (*i == I_CMD_NONE) {
+            *i = lastCmd_;
+            isDirty_ = true;
+        } else {
+            lastCmd_ = *i;
+        }
+        break;
 
-		case 5:
-/*			s=phrase_->param2_+(16*viewData_->currentPhrase_+row_) ;
-			if (*s==0) {
-				*s=lastParam_ ;
-				isDirty_=true ;
-				cmdEdit_.SetInt(lastParam_) ;
-			}
-*/			break ;
-	} 
+    case 3:
+        /*			s=phrase_->param1_+(16*viewData_->currentPhrase_+row_) ;
+                    if (*s==0) {
+                        *s=lastParam_ ;
+                        cmdEdit_.SetInt(lastParam_) ;
+                        isDirty_=true ;
+                    }
+        �*/
+        break;
+
+    case 4:
+        i = phrase_->cmd2_ + (16 * viewData_->currentPhrase_ + row_);
+        if (*i == I_CMD_NONE) {
+            *i = lastCmd_;
+            isDirty_ = true;
+        } else {
+            lastCmd_ = *i;
+        }
+        break;
+
+    case 5:
+        /*			s=phrase_->param2_+(16*viewData_->currentPhrase_+row_) ;
+                    if (*s==0) {
+                        *s=lastParam_ ;
+                        isDirty_=true ;
+                        cmdEdit_.SetInt(lastParam_) ;
+                    }
+        */
+        break;
+    }
 }
 
 void PhraseView::cutPosition() {
 
-    clipboard_.active_=true ;
-    clipboard_.row_=row_ ;
-    clipboard_.col_=col_ ;
-    saveRow_=row_ ;
-	saveCol_=col_ ;
+    clipboard_.active_ = true;
+    clipboard_.row_ = row_;
+    clipboard_.col_ = col_;
+    saveRow_ = row_;
+    saveCol_ = col_;
 
-	if (col_%2==0) col_+=1 ; // This way, A+B on note cuts
-						   // the instruments too and parameters get cut with commands
-    cutSelection() ;
-} ;
+    if (col_ % 2 == 0)
+        col_ += 1; // This way, A+B on note cuts
+                   // the instruments too and parameters get cut with commands
+    cutSelection();
+};
 
 void PhraseView::warpInChain(int offset) {
 
-    int currentRow=viewData_->chainRow_ ;
-    viewData_->chainRow_+=offset ;
-    if ((viewData_->chainRow_<16)&&
-        (viewData_->chainRow_>=0)) {
- 			unsigned char *p=viewData_->GetCurrentChainPointer() ;
-			if (*p!=0xFF) {
-				viewData_->currentPhrase_=*p ;
-				switch(col_) {
-					case 3:
-						cmdEdit_.SetInt(*(phrase_->param1_+(16*viewData_->currentPhrase_+row_))) ;
-						break ;
-					case 5:
-						cmdEdit_.SetInt(*(phrase_->param2_+(16*viewData_->currentPhrase_+row_))) ;
-						break ;
-				} ;
-			} else { // rollback
-				viewData_->chainRow_=currentRow ;
-			}           
+    int currentRow = viewData_->chainRow_;
+    viewData_->chainRow_ += offset;
+    if ((viewData_->chainRow_ < 16) && (viewData_->chainRow_ >= 0)) {
+        unsigned char *p = viewData_->GetCurrentChainPointer();
+        if (*p != 0xFF) {
+            viewData_->currentPhrase_ = *p;
+            switch (col_) {
+            case 3:
+                cmdEdit_.SetInt(*(phrase_->param1_ +
+                                  (16 * viewData_->currentPhrase_ + row_)));
+                break;
+            case 5:
+                cmdEdit_.SetInt(*(phrase_->param2_ +
+                                  (16 * viewData_->currentPhrase_ + row_)));
+                break;
+            };
+        } else { // rollback
+            viewData_->chainRow_ = currentRow;
+        }
     } else { // rollback
-        viewData_->chainRow_=currentRow ;
+        viewData_->chainRow_ = currentRow;
     }
-    isDirty_=true ;
+    isDirty_ = true;
 }
 
 void PhraseView::warpToNeighbour(int offset) {
-	// save current data
-	int saveX = viewData_->songX_;
-	int saveOffset = viewData_->songOffset_;
-	int newPos = saveX + offset;
+    // save current data
+    int saveX = viewData_->songX_;
+    int saveOffset = viewData_->songOffset_;
+    int newPos = saveX + offset;
 
-	while ((newPos > -1) && (newPos<SONG_CHANNEL_COUNT)) {
-		// Go to neighbout song channel
-		viewData_->songX_=newPos ;
-		unsigned char *c=viewData_->GetCurrentSongPointer() ;
-		// is there a chain ?
-		unsigned char oldChain=viewData_->currentChain_ ;
-		if (*c!=0xFF) {
-			// go to chain
-			viewData_->currentChain_=*c ;
-			// get phrase at location
-			unsigned char *p=viewData_->GetCurrentChainPointer() ;
-			// is there a phrase ?
-			if (*p!=0xFF) {
-				viewData_->currentPhrase_=*p ;
-				updateCursor(0,0) ;
-				isDirty_=true ;
-				return;
-			} else {
-				viewData_->currentPhrase_ = 0xFE;
-				viewData_->currentChain_ = *c;
-				updateCursor(0,0);
-				isDirty_ = true;
-				return;
-			}
-		} else {
-			// no chain, to neighbour song channel
-			newPos += offset;
-		}
-	}
-	// restore song
-	viewData_->songX_ = saveX;
-	viewData_->songOffset_ = saveOffset;
+    while ((newPos > -1) && (newPos < SONG_CHANNEL_COUNT)) {
+        // Go to neighbout song channel
+        viewData_->songX_ = newPos;
+        unsigned char *c = viewData_->GetCurrentSongPointer();
+        // is there a chain ?
+        unsigned char oldChain = viewData_->currentChain_;
+        if (*c != 0xFF) {
+            // go to chain
+            viewData_->currentChain_ = *c;
+            // get phrase at location
+            unsigned char *p = viewData_->GetCurrentChainPointer();
+            // is there a phrase ?
+            if (*p != 0xFF) {
+                viewData_->currentPhrase_ = *p;
+                updateCursor(0, 0);
+                isDirty_ = true;
+                return;
+            } else {
+                viewData_->currentPhrase_ = 0xFE;
+                viewData_->currentChain_ = *c;
+                updateCursor(0, 0);
+                isDirty_ = true;
+                return;
+            }
+        } else {
+            // no chain, to neighbour song channel
+            newPos += offset;
+        }
+    }
+    // restore song
+    viewData_->songX_ = saveX;
+    viewData_->songOffset_ = saveOffset;
 }
 
 /******************************************************
@@ -391,105 +394,109 @@ void PhraseView::warpToNeighbour(int offset) {
         gets the normalized rectangle of the current
         selection. Valid only while selection is drawn
  ******************************************************/
- 
-GUIRect PhraseView::getSelectionRect() {
-    GUIRect r(clipboard_.col_,clipboard_.row_,col_,row_) ;
-    r.Normalize() ;
-    return r ;
-} ;
 
+GUIRect PhraseView::getSelectionRect() {
+    GUIRect r(clipboard_.col_, clipboard_.row_, col_, row_);
+    r.Normalize();
+    return r;
+};
 
 /******************************************************
  fillClipboardData:
-        
+
         copies the necessary information from the
         current selection to the clipboard for future
         paste. We're copying data all across the row
         because we"re too lazy to try to figure a better
         procedure
  ******************************************************/
- 
+
 void PhraseView::fillClipboardData() {
 
-  // Get Current normalized selection rect
-  
-    GUIRect selRect=getSelectionRect() ;
+    // Get Current normalized selection rect
 
-  // Get size & store in clipboard
-  
-    clipboard_.width_=selRect.Width()+1 ;
-    clipboard_.height_=selRect.Height()+1 ;
-    clipboard_.row_=selRect.Top() ;
-    clipboard_.col_=selRect.Left() ;
-      
-  // Copy the data
-    
-    uchar *src1=viewData_->song_->phrase_->note_+16*viewData_->currentPhrase_ ;
-    uchar *dst1=clipboard_.note_ ;
-    uchar *src2=viewData_->song_->phrase_->instr_+16*viewData_->currentPhrase_ ;
-    uchar *dst2=clipboard_.instr_ ;
-    uint *src3=viewData_->song_->phrase_->cmd1_+16*viewData_->currentPhrase_ ;
-    uint *dst3=clipboard_.cmd1_ ;
-    ushort *src4=viewData_->song_->phrase_->param1_+16*viewData_->currentPhrase_ ;
-    ushort *dst4=clipboard_.param1_ ;
-    uint *src5=viewData_->song_->phrase_->cmd2_+16*viewData_->currentPhrase_ ;
-    uint *dst5=clipboard_.cmd2_ ;
-    ushort *src6=viewData_->song_->phrase_->param2_+16*viewData_->currentPhrase_ ;
-    ushort *dst6=clipboard_.param2_ ;
-    
-    for (int i=0;i<clipboard_.height_;i++) {
-        dst1[i]=src1[clipboard_.row_+i] ;
-        dst2[i]=src2[clipboard_.row_+i] ;
-        dst3[i]=src3[clipboard_.row_+i] ;
-        dst4[i]=src4[clipboard_.row_+i] ;
-        dst5[i]=src5[clipboard_.row_+i] ;
-        dst6[i]=src6[clipboard_.row_+i] ;
-    } ;
-	updateCursor(0,0) ;
-} ;
+    GUIRect selRect = getSelectionRect();
 
+    // Get size & store in clipboard
+
+    clipboard_.width_ = selRect.Width() + 1;
+    clipboard_.height_ = selRect.Height() + 1;
+    clipboard_.row_ = selRect.Top();
+    clipboard_.col_ = selRect.Left();
+
+    // Copy the data
+
+    uchar *src1 =
+        viewData_->song_->phrase_->note_ + 16 * viewData_->currentPhrase_;
+    uchar *dst1 = clipboard_.note_;
+    uchar *src2 =
+        viewData_->song_->phrase_->instr_ + 16 * viewData_->currentPhrase_;
+    uchar *dst2 = clipboard_.instr_;
+    uint *src3 =
+        viewData_->song_->phrase_->cmd1_ + 16 * viewData_->currentPhrase_;
+    uint *dst3 = clipboard_.cmd1_;
+    ushort *src4 =
+        viewData_->song_->phrase_->param1_ + 16 * viewData_->currentPhrase_;
+    ushort *dst4 = clipboard_.param1_;
+    uint *src5 =
+        viewData_->song_->phrase_->cmd2_ + 16 * viewData_->currentPhrase_;
+    uint *dst5 = clipboard_.cmd2_;
+    ushort *src6 =
+        viewData_->song_->phrase_->param2_ + 16 * viewData_->currentPhrase_;
+    ushort *dst6 = clipboard_.param2_;
+
+    for (int i = 0; i < clipboard_.height_; i++) {
+        dst1[i] = src1[clipboard_.row_ + i];
+        dst2[i] = src2[clipboard_.row_ + i];
+        dst3[i] = src3[clipboard_.row_ + i];
+        dst4[i] = src4[clipboard_.row_ + i];
+        dst5[i] = src5[clipboard_.row_ + i];
+        dst6[i] = src6[clipboard_.row_ + i];
+    };
+    updateCursor(0, 0);
+};
 
 void PhraseView::updateSelectionValue(ViewUpdateDirection direction) { // HERE
 
-	saveRow_=row_ ;
-	saveCol_=col_ ;
+    saveRow_ = row_;
+    saveCol_ = col_;
 
-	GUIRect r=getSelectionRect() ;
-	col_=r.Left() ;
-    row_ =r.Top() ;
+    GUIRect r = getSelectionRect();
+    col_ = r.Left();
+    row_ = r.Top();
 
-	for (int i=0;i<=r.Width();i++) {
-		for (int j=0;j<=r.Height();j++) {
-			if (col_+i<2) {		
-				updateCursorValue(direction,i,j) ;
-			}
-		}
-	}
-	row_=saveRow_ ;
-	col_=saveCol_ ;
+    for (int i = 0; i <= r.Width(); i++) {
+        for (int j = 0; j <= r.Height(); j++) {
+            if (col_ + i < 2) {
+                updateCursorValue(direction, i, j);
+            }
+        }
+    }
+    row_ = saveRow_;
+    col_ = saveCol_;
 }
 
 void PhraseView::extendSelection() {
-	GUIRect rect=getSelectionRect() ;
-	if (rect.Left()>0||rect.Right()<5) {
-		if (col_<clipboard_.col_) {
-			col_=0 ;
-			clipboard_.col_=5 ;
-		} else {
-			col_=5 ;
-			clipboard_.col_=0 ;
-		}
-		isDirty_=true ;
-	} else {
-		if (row_<clipboard_.row_) {
-			row_=0 ;
-			clipboard_.row_=15 ;
-		} else {
-			clipboard_.row_=0 ;
-			row_=15 ;
-		}
-		isDirty_=true ;
-	}
+    GUIRect rect = getSelectionRect();
+    if (rect.Left() > 0 || rect.Right() < 5) {
+        if (col_ < clipboard_.col_) {
+            col_ = 0;
+            clipboard_.col_ = 5;
+        } else {
+            col_ = 5;
+            clipboard_.col_ = 0;
+        }
+        isDirty_ = true;
+    } else {
+        if (row_ < clipboard_.row_) {
+            row_ = 0;
+            clipboard_.row_ = 15;
+        } else {
+            clipboard_.row_ = 0;
+            row_ = 15;
+        }
+        isDirty_ = true;
+    }
 }
 /******************************************************
  copySelection:
@@ -499,17 +506,17 @@ void PhraseView::extendSelection() {
 
 void PhraseView::copySelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
-    
-    fillClipboardData() ;
-    
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    row_=saveRow_ ;
-    col_=saveCol_ ;
-    
-	View::SetNotification("Copied selection");
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
+
+    fillClipboardData();
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    row_ = saveRow_;
+    col_ = saveCol_;
+
+    View::SetNotification("Copied selection");
 };
 
 /******************************************************
@@ -517,57 +524,63 @@ void PhraseView::copySelection() {
        clipboard, clear selection content & end selection
        process
  ******************************************************/
- 
+
 void PhraseView::cutSelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
-     
-    fillClipboardData() ;
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
 
-// Loop over selection col, row & clear data inside it
+    fillClipboardData();
 
-    uchar *dst1=viewData_->song_->phrase_->note_+16*viewData_->currentPhrase_ ;
-    uchar *dst2=viewData_->song_->phrase_->instr_+16*viewData_->currentPhrase_ ;
-    uint *dst3=viewData_->song_->phrase_->cmd1_+16*viewData_->currentPhrase_ ;
-    ushort *dst4=viewData_->song_->phrase_->param1_+16*viewData_->currentPhrase_ ;
-    uint *dst5=viewData_->song_->phrase_->cmd2_+16*viewData_->currentPhrase_ ;
-    ushort *dst6=viewData_->song_->phrase_->param2_+16*viewData_->currentPhrase_ ;
+    // Loop over selection col, row & clear data inside it
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<clipboard_.height_;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                    dst1[j+clipboard_.row_]=0xFF ;
-                    break ;
-                case 1:
-                    dst2[j+clipboard_.row_]=0xFF ;
-                    break ;
-                case 2:
-                    dst3[j+clipboard_.row_]=I_CMD_NONE ;
-                    break ;
-                case 3:
-                    dst4[j+clipboard_.row_]=0x0000 ;
-                    break ;
-                case 4:
-                    dst5[j+clipboard_.row_]=I_CMD_NONE ;
-                    break ;
-                case 5:
-                    dst6[j+clipboard_.row_]=0x0000 ;
-                    break ;
+    uchar *dst1 =
+        viewData_->song_->phrase_->note_ + 16 * viewData_->currentPhrase_;
+    uchar *dst2 =
+        viewData_->song_->phrase_->instr_ + 16 * viewData_->currentPhrase_;
+    uint *dst3 =
+        viewData_->song_->phrase_->cmd1_ + 16 * viewData_->currentPhrase_;
+    ushort *dst4 =
+        viewData_->song_->phrase_->param1_ + 16 * viewData_->currentPhrase_;
+    uint *dst5 =
+        viewData_->song_->phrase_->cmd2_ + 16 * viewData_->currentPhrase_;
+    ushort *dst6 =
+        viewData_->song_->phrase_->param2_ + 16 * viewData_->currentPhrase_;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < clipboard_.height_; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+                dst1[j + clipboard_.row_] = 0xFF;
+                break;
+            case 1:
+                dst2[j + clipboard_.row_] = 0xFF;
+                break;
+            case 2:
+                dst3[j + clipboard_.row_] = I_CMD_NONE;
+                break;
+            case 3:
+                dst4[j + clipboard_.row_] = 0x0000;
+                break;
+            case 4:
+                dst5[j + clipboard_.row_] = I_CMD_NONE;
+                break;
+            case 5:
+                dst6[j + clipboard_.row_] = 0x0000;
+                break;
             }
         }
     }
-    
-// Clear selection, end selection process & reposition cursor
 
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    row_=saveRow_ ;
-    col_=saveCol_ ;
-	updateCursor(0,0) ;
-    isDirty_=true ; 
-} ;
+    // Clear selection, end selection process & reposition cursor
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    row_ = saveRow_;
+    col_ = saveCol_;
+    updateCursor(0, 0);
+    isDirty_ = true;
+};
 
 /******************************************************
  pasteClipboard:
@@ -576,721 +589,791 @@ void PhraseView::cutSelection() {
 
 void PhraseView::pasteClipboard() {
 
- // Get number of row to paste
- 
-    int height=clipboard_.height_ ;
-/*    if (row_+height>16) {
-        height=16-row_ ;
-    }
-  */  
-    uchar *dst1=viewData_->song_->phrase_->note_+16*viewData_->currentPhrase_ ;
-    uchar *src1=clipboard_.note_ ;
-    uchar *dst2=viewData_->song_->phrase_->instr_+16*viewData_->currentPhrase_ ;
-    uchar *src2=clipboard_.instr_ ;
-    uint *dst3=viewData_->song_->phrase_->cmd1_+16*viewData_->currentPhrase_ ;
-    uint *src3=clipboard_.cmd1_ ;
-    ushort *dst4=viewData_->song_->phrase_->param1_+16*viewData_->currentPhrase_ ;
-    ushort *src4=clipboard_.param1_ ;
-    uint *dst5=viewData_->song_->phrase_->cmd2_+16*viewData_->currentPhrase_ ;
-    uint *src5=clipboard_.cmd2_ ;
-    ushort *dst6=viewData_->song_->phrase_->param2_+16*viewData_->currentPhrase_ ;
-    ushort *src6=clipboard_.param2_ ;
+    // Get number of row to paste
 
-	uint* noCmd = (uint*) -1;
-	ushort* noPrm = (ushort*) -1;
-	uint* srcCmd[5] = {noCmd, noCmd, src3, noCmd, src5};
-	ushort* srcPrm[6] = {noPrm, noPrm, noPrm, src4, noPrm, src6};
-	uint* dstCmd[5] = {noCmd, noCmd, dst3, noCmd, dst5};
-	ushort* dstPrm[6] = {noPrm, noPrm, noPrm, dst4, noPrm, dst6};
+    int height = clipboard_.height_;
+    /*    if (row_+height>16) {
+            height=16-row_ ;
+        }
+      */
+    uchar *dst1 =
+        viewData_->song_->phrase_->note_ + 16 * viewData_->currentPhrase_;
+    uchar *src1 = clipboard_.note_;
+    uchar *dst2 =
+        viewData_->song_->phrase_->instr_ + 16 * viewData_->currentPhrase_;
+    uchar *src2 = clipboard_.instr_;
+    uint *dst3 =
+        viewData_->song_->phrase_->cmd1_ + 16 * viewData_->currentPhrase_;
+    uint *src3 = clipboard_.cmd1_;
+    ushort *dst4 =
+        viewData_->song_->phrase_->param1_ + 16 * viewData_->currentPhrase_;
+    ushort *src4 = clipboard_.param1_;
+    uint *dst5 =
+        viewData_->song_->phrase_->cmd2_ + 16 * viewData_->currentPhrase_;
+    uint *src5 = clipboard_.cmd2_;
+    ushort *dst6 =
+        viewData_->song_->phrase_->param2_ + 16 * viewData_->currentPhrase_;
+    ushort *src6 = clipboard_.param2_;
 
-	bool wasUpdated = false;
+    uint *noCmd = (uint *)-1;
+    ushort *noPrm = (ushort *)-1;
+    uint *srcCmd[5] = {noCmd, noCmd, src3, noCmd, src5};
+    ushort *srcPrm[6] = {noPrm, noPrm, noPrm, src4, noPrm, src6};
+    uint *dstCmd[5] = {noCmd, noCmd, dst3, noCmd, dst5};
+    ushort *dstPrm[6] = {noPrm, noPrm, noPrm, dst4, noPrm, dst6};
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<height;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                    dst1[(j+row_)%16]=src1[j] ;
-					wasUpdated = true;
-                    break ;
-                case 1:
-                    dst2[(j+row_)%16]=src2[j] ;
-					wasUpdated = true;
-                    break ;
-                case 2:
-                case 4:
-					if ((col_ + i) == 2 || (col_ + i) == 4) { // Don't allow commands in notes, etc
-						dstCmd[col_ + i][(row_ + j)%16] = srcCmd[clipboard_.col_ + i][j];
-						wasUpdated = true;
-					}
-                    break;
-                case 3:
-                case 5:
-					if ((col_ + i) == 3 || (col_ + i) == 5) {
-						dstPrm[col_ + i][(row_ + j)%16] = srcPrm[clipboard_.col_ + i][j];
-						wasUpdated = true;
-					}
-                    break;
+    bool wasUpdated = false;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < height; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+                dst1[(j + row_) % 16] = src1[j];
+                wasUpdated = true;
+                break;
+            case 1:
+                dst2[(j + row_) % 16] = src2[j];
+                wasUpdated = true;
+                break;
+            case 2:
+            case 4:
+                if ((col_ + i) == 2 ||
+                    (col_ + i) == 4) { // Don't allow commands in notes, etc
+                    dstCmd[col_ + i][(row_ + j) % 16] =
+                        srcCmd[clipboard_.col_ + i][j];
+                    wasUpdated = true;
+                }
+                break;
+            case 3:
+            case 5:
+                if ((col_ + i) == 3 || (col_ + i) == 5) {
+                    dstPrm[col_ + i][(row_ + j) % 16] =
+                        srcPrm[clipboard_.col_ + i][j];
+                    wasUpdated = true;
+                }
+                break;
             }
         }
     }
-	if (wasUpdated) {
-		updateCursor(0x00, ((row_ + height)%16 - row_));
-		isDirty_ = true;
-	}
-} ;
+    if (wasUpdated) {
+        updateCursor(0x00, ((row_ + height) % 16 - row_));
+        isDirty_ = true;
+    }
+};
 
 void PhraseView::unMuteAll() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->UnMuteAll() ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->UnMuteAll();
+};
 
 void PhraseView::toggleMute() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->ToggleMute(viewData_->songX_,viewData_->songX_) ;
-	viewMode_=(viewMode_!=VM_MUTEON)?VM_MUTEON:VM_NORMAL ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->ToggleMute(viewData_->songX_, viewData_->songX_);
+    viewMode_ = (viewMode_ != VM_MUTEON) ? VM_MUTEON : VM_NORMAL;
+};
 
 void PhraseView::switchSoloMode() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->SwitchSoloMode(viewData_->songX_,viewData_->songX_,(viewMode_==VM_NORMAL)) ;
-	viewMode_=(viewMode_!=VM_SOLOON)?VM_SOLOON:VM_NORMAL ;
-    isDirty_=true ;
-} ;
-
-
+    UIController *controller = UIController::GetInstance();
+    controller->SwitchSoloMode(viewData_->songX_, viewData_->songX_,
+                               (viewMode_ == VM_NORMAL));
+    viewMode_ = (viewMode_ != VM_SOLOON) ? VM_SOLOON : VM_NORMAL;
+    isDirty_ = true;
+};
 
 void PhraseView::OnFocus() {
-	clipboard_.active_=false ;
-	viewMode_=VM_NORMAL ;
-	updateCursor(0,0) ;
-}; 
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    updateCursor(0, 0);
+};
 
-void PhraseView::ProcessButtonMask(unsigned short mask,bool pressed) {
+void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
-	if (!pressed) {
-		if (viewMode_==VM_MUTEON) {
-			if (mask&EPBM_R) {
-				toggleMute() ;
-			}
-		} ;
-		if (viewMode_==VM_SOLOON) {
-			if (mask&EPBM_R) {
-				switchSoloMode() ;
-			}
-		} ;
-		return ;
-	} ;
+    if (!pressed) {
+        if (viewMode_ == VM_MUTEON) {
+            if (mask & EPBM_R) {
+                toggleMute();
+            }
+        };
+        if (viewMode_ == VM_SOLOON) {
+            if (mask & EPBM_R) {
+                switchSoloMode();
+            }
+        };
+        return;
+    };
 
+    if (viewMode_ == VM_NEW) {
+        if (mask == EPBM_A) {
 
- 	if (viewMode_==VM_NEW) {
-		if (mask==EPBM_A) {
+            // If note or I, we request a new instr
 
-			// If note or I, we request a new instr
-
-			if (col_<2) {
-				InstrumentBank *bank=viewData_->project_->GetInstrumentBank() ;
-				unsigned short next=bank->GetNext() ;
-				if (next!=NO_MORE_INSTRUMENT) {
-					unsigned char *c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-					*c= (unsigned char) next;
-					lastInstr_=next ;
-					isDirty_=true ;
-				}
-				mask&=(0xFFFF-EPBM_A) ;
-			} else {
-				if ((col_==3)&&(*(phrase_->cmd1_+(16*viewData_->currentPhrase_+row_)))==I_CMD_TABL) {
-					TableHolder *th=TableHolder::GetInstance() ;
-					unsigned short next=th->GetNext() ;
-					if (next!=NO_MORE_TABLE) {
-						ushort *c=phrase_->param1_+(16*viewData_->currentPhrase_+row_) ;
-						*c=next ;
-						isDirty_=true ;
-						mask&=(0xFFFF-EPBM_A) ;
-						cmdEdit_.SetInt(next) ;
-					}
-				}
-				if ((col_==5)&&(*(phrase_->cmd2_+(16*viewData_->currentPhrase_+row_)))==I_CMD_TABL) {
-					TableHolder *th=TableHolder::GetInstance() ;
-					unsigned short next=th->GetNext() ;
-					if (next!=NO_MORE_TABLE) {
-						ushort *c=phrase_->param2_+(16*viewData_->currentPhrase_+row_) ;
-						*c=next ;
-						isDirty_=true ;
-						mask&=(0xFFFF-EPBM_A) ;
-						cmdEdit_.SetInt(next) ;
-					}
-				}
-			} ;
-		}
-	}
-
-	if (viewMode_==VM_CLONE) {
-        if ((mask&EPBM_A)&&(mask&EPBM_L)) {
-			if (col_<2) {
-				InstrumentBank *bank=viewData_->project_->GetInstrumentBank() ;
-				unsigned char *c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-				if (*c!=0xFF) {
-					unsigned short next=bank->Clone(*c) ;
-					if (next!=NO_MORE_INSTRUMENT) {
-						*c=(unsigned char)next ;
-						lastInstr_=next ;
-						isDirty_=true ;
-					} else {
-						View::SetNotification("No more instruments");
-					}
-				}
-			}else {
-				if ((col_==3)&&(*(phrase_->cmd1_+(16*viewData_->currentPhrase_+row_)))==I_CMD_TABL) {
-					TableHolder *th=TableHolder::GetInstance() ;
-					int current=*(phrase_->param1_+(16*viewData_->currentPhrase_+row_)) ;
-					if (current!=-1) {
-						unsigned short next=th->Clone(current) ;
-						if (next!=NO_MORE_TABLE) {
-							ushort *c=phrase_->param1_+(16*viewData_->currentPhrase_+row_) ;
-							*c=next ;
-							isDirty_=true ;
-							cmdEdit_.SetInt(next) ;
-						} else {
-							View::SetNotification("No more tables");
-						}
-					}
-				}
-				if ((col_==5)&&(*(phrase_->cmd2_+(16*viewData_->currentPhrase_+row_)))==I_CMD_TABL) {
-					TableHolder *th=TableHolder::GetInstance() ;
-					unsigned short next=th->Clone(*(phrase_->param2_+(16*viewData_->currentPhrase_+row_))) ;
-					if (next!=NO_MORE_TABLE) {
-						ushort *c=phrase_->param2_+(16*viewData_->currentPhrase_+row_) ;
-						*c=next ;
-						isDirty_=true ;
-						cmdEdit_.SetInt(next) ;
-					} else {
-						View::SetNotification("No more tables");
-					}
-				}
-			} ;
-			mask&=(0xFFFF-(EPBM_A|EPBM_L)) ;
-        } else {
-            viewMode_=VM_SELECTION ;
+            if (col_ < 2) {
+                InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
+                unsigned short next = bank->GetNext();
+                if (next != NO_MORE_INSTRUMENT) {
+                    unsigned char *c = phrase_->instr_ +
+                                       (16 * viewData_->currentPhrase_ + row_);
+                    *c = (unsigned char)next;
+                    lastInstr_ = next;
+                    isDirty_ = true;
+                }
+                mask &= (0xFFFF - EPBM_A);
+            } else {
+                if ((col_ == 3) &&
+                    (*(phrase_->cmd1_ + (16 * viewData_->currentPhrase_ +
+                                         row_))) == I_CMD_TABL) {
+                    TableHolder *th = TableHolder::GetInstance();
+                    unsigned short next = th->GetNext();
+                    if (next != NO_MORE_TABLE) {
+                        ushort *c = phrase_->param1_ +
+                                    (16 * viewData_->currentPhrase_ + row_);
+                        *c = next;
+                        isDirty_ = true;
+                        mask &= (0xFFFF - EPBM_A);
+                        cmdEdit_.SetInt(next);
+                    }
+                }
+                if ((col_ == 5) &&
+                    (*(phrase_->cmd2_ + (16 * viewData_->currentPhrase_ +
+                                         row_))) == I_CMD_TABL) {
+                    TableHolder *th = TableHolder::GetInstance();
+                    unsigned short next = th->GetNext();
+                    if (next != NO_MORE_TABLE) {
+                        ushort *c = phrase_->param2_ +
+                                    (16 * viewData_->currentPhrase_ + row_);
+                        *c = next;
+                        isDirty_ = true;
+                        mask &= (0xFFFF - EPBM_A);
+                        cmdEdit_.SetInt(next);
+                    }
+                }
+            };
         }
-    } ;
+    }
 
-	if (viewMode_==VM_SELECTION) {
-		if (!clipboard_.active_) {
-			clipboard_.active_=true ;
-			clipboard_.col_=col_ ;
-			clipboard_.row_=row_ ;
-			saveCol_=col_ ;
-			saveRow_=row_ ;
-		}
-		processSelectionButtonMask(mask) ;
-	}  else {
-		viewMode_=VM_NORMAL ;
-		processNormalButtonMask(mask) ;
-	} ;
+    if (viewMode_ == VM_CLONE) {
+        if ((mask & EPBM_A) && (mask & EPBM_L)) {
+            if (col_ < 2) {
+                InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
+                unsigned char *c =
+                    phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
+                if (*c != 0xFF) {
+                    unsigned short next = bank->Clone(*c);
+                    if (next != NO_MORE_INSTRUMENT) {
+                        *c = (unsigned char)next;
+                        lastInstr_ = next;
+                        isDirty_ = true;
+                    } else {
+                        View::SetNotification("No more instruments");
+                    }
+                }
+            } else {
+                if ((col_ == 3) &&
+                    (*(phrase_->cmd1_ + (16 * viewData_->currentPhrase_ +
+                                         row_))) == I_CMD_TABL) {
+                    TableHolder *th = TableHolder::GetInstance();
+                    int current = *(phrase_->param1_ +
+                                    (16 * viewData_->currentPhrase_ + row_));
+                    if (current != -1) {
+                        unsigned short next = th->Clone(current);
+                        if (next != NO_MORE_TABLE) {
+                            ushort *c = phrase_->param1_ +
+                                        (16 * viewData_->currentPhrase_ + row_);
+                            *c = next;
+                            isDirty_ = true;
+                            cmdEdit_.SetInt(next);
+                        } else {
+                            View::SetNotification("No more tables");
+                        }
+                    }
+                }
+                if ((col_ == 5) &&
+                    (*(phrase_->cmd2_ + (16 * viewData_->currentPhrase_ +
+                                         row_))) == I_CMD_TABL) {
+                    TableHolder *th = TableHolder::GetInstance();
+                    unsigned short next =
+                        th->Clone(*(phrase_->param2_ +
+                                    (16 * viewData_->currentPhrase_ + row_)));
+                    if (next != NO_MORE_TABLE) {
+                        ushort *c = phrase_->param2_ +
+                                    (16 * viewData_->currentPhrase_ + row_);
+                        *c = next;
+                        isDirty_ = true;
+                        cmdEdit_.SetInt(next);
+                    } else {
+                        View::SetNotification("No more tables");
+                    }
+                }
+            };
+            mask &= (0xFFFF - (EPBM_A | EPBM_L));
+        } else {
+            viewMode_ = VM_SELECTION;
+        }
+    };
+
+    if (viewMode_ == VM_SELECTION) {
+        if (!clipboard_.active_) {
+            clipboard_.active_ = true;
+            clipboard_.col_ = col_;
+            clipboard_.row_ = row_;
+            saveCol_ = col_;
+            saveRow_ = row_;
+        }
+        processSelectionButtonMask(mask);
+    } else {
+        viewMode_ = VM_NORMAL;
+        processNormalButtonMask(mask);
+    };
 }
 
 void PhraseView::processNormalButtonMask(unsigned short mask) {
 
-	// B Modifier
-	
-	Player *player=Player::GetInstance() ;
+    // B Modifier
 
-	if (mask&EPBM_B) {
-		if (mask&EPBM_LEFT) warpToNeighbour(-1) ;
-		if (mask&EPBM_RIGHT) warpToNeighbour(1);
-		if (mask&EPBM_UP) warpInChain(-1) ;
-		if (mask&EPBM_DOWN) warpInChain(1);
-		if (mask&EPBM_A) {
-			stopAudition();
-			cutPosition();
-			}
-        if (mask&EPBM_L) {
-            viewMode_=VM_CLONE ;
-        } ;
- 	    if (mask&EPBM_R) toggleMute() ;
- 	    if (mask&EPBM_B) stopAudition() ;
+    Player *player = Player::GetInstance();
 
-	} else {
-        
-      // A Modifer
-      
-	  if (mask&EPBM_A) {
-		if (mask&EPBM_DOWN) updateCursorValue(VUD_DOWN) ;
-		if (mask&EPBM_UP) updateCursorValue(VUD_UP) ;
-		if (mask&EPBM_LEFT) updateCursorValue(VUD_LEFT) ;
-		if (mask&EPBM_RIGHT) updateCursorValue(VUD_RIGHT) ;
-		if (mask&EPBM_L) pasteClipboard() ;
-		if (mask&EPBM_R) switchSoloMode() ;
-		if (mask==EPBM_A) {
-			pasteLast() ;
-			if ((col_==1)||(col_==3)||(col_==5)) viewMode_=VM_NEW ;
-		}
-
-	  } else {
-            	
-		// R Modifier
-        
-        if (mask&EPBM_R) {
-			if (mask&EPBM_LEFT) {
-					stopAudition();
-					ViewType vt=VT_CHAIN ;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-			}
-			if (mask&EPBM_RIGHT) {
-				stopAudition();
-				unsigned char *c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-				if (*c!=0xFF) {
-					viewData_->currentInstrument_=*c ;
-				} else {
-					viewData_->currentInstrument_=lastInstr_ ;
-				}
-        if (viewData_->currentInstrument_ != 0xFF)
-        {
-          ViewType vt=VT_INSTRUMENT ;
-          ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-          SetChanged();
-          NotifyObservers(&ve) ;          
+    if (mask & EPBM_B) {
+        if (mask & EPBM_LEFT)
+            warpToNeighbour(-1);
+        if (mask & EPBM_RIGHT)
+            warpToNeighbour(1);
+        if (mask & EPBM_UP)
+            warpInChain(-1);
+        if (mask & EPBM_DOWN)
+            warpInChain(1);
+        if (mask & EPBM_A) {
+            stopAudition();
+            cutPosition();
         }
-			}
-			if (mask&EPBM_DOWN) {
+        if (mask & EPBM_L) {
+            viewMode_ = VM_CLONE;
+        };
+        if (mask & EPBM_R)
+            toggleMute();
+        if (mask & EPBM_B)
+            stopAudition();
 
-				// Go to table view
-					stopAudition();
+    } else {
 
-					ViewType vt=VT_TABLE ;
+        // A Modifer
 
-					FourCC *cmd=phrase_->cmd1_+(16*viewData_->currentPhrase_+row_) ;
-					ushort *param=phrase_->param1_+(16*viewData_->currentPhrase_+row_) ;
+        if (mask & EPBM_A) {
+            if (mask & EPBM_DOWN)
+                updateCursorValue(VUD_DOWN);
+            if (mask & EPBM_UP)
+                updateCursorValue(VUD_UP);
+            if (mask & EPBM_LEFT)
+                updateCursorValue(VUD_LEFT);
+            if (mask & EPBM_RIGHT)
+                updateCursorValue(VUD_RIGHT);
+            if (mask & EPBM_L)
+                pasteClipboard();
+            if (mask & EPBM_R)
+                switchSoloMode();
+            if (mask == EPBM_A) {
+                pasteLast();
+                if ((col_ == 1) || (col_ == 3) || (col_ == 5))
+                    viewMode_ = VM_NEW;
+            }
 
-					if (*cmd!=I_CMD_TABL) {
-						cmd=phrase_->cmd2_+(16*viewData_->currentPhrase_+row_) ;
-						param=phrase_->param2_+(16*viewData_->currentPhrase_+row_) ;
-					}
-					if (*cmd==I_CMD_TABL) {
-						viewData_->currentTable_=(*param)&0x7F ;
-					}
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-			}
+        } else {
 
-			if (mask&EPBM_UP) {
+            // R Modifier
 
-				// Go to groove view
-					stopAudition();
+            if (mask & EPBM_R) {
+                if (mask & EPBM_LEFT) {
+                    stopAudition();
+                    ViewType vt = VT_CHAIN;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+                if (mask & EPBM_RIGHT) {
+                    stopAudition();
+                    unsigned char *c = phrase_->instr_ +
+                                       (16 * viewData_->currentPhrase_ + row_);
+                    if (*c != 0xFF) {
+                        viewData_->currentInstrument_ = *c;
+                    } else {
+                        viewData_->currentInstrument_ = lastInstr_;
+                    }
+                    if (viewData_->currentInstrument_ != 0xFF) {
+                        ViewType vt = VT_INSTRUMENT;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
+                if (mask & EPBM_DOWN) {
 
-					ViewType vt=VT_GROOVE;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-			}
+                    // Go to table view
+                    stopAudition();
 
-			if (mask&EPBM_START) {
-				player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
-    		}			
-			if (mask&EPBM_L) unMuteAll() ;
+                    ViewType vt = VT_TABLE;
 
-		} else {
-            // L Modifier
-            if (mask&EPBM_L) {
+                    FourCC *cmd = phrase_->cmd1_ +
+                                  (16 * viewData_->currentPhrase_ + row_);
+                    ushort *param = phrase_->param1_ +
+                                    (16 * viewData_->currentPhrase_ + row_);
+
+                    if (*cmd != I_CMD_TABL) {
+                        cmd = phrase_->cmd2_ +
+                              (16 * viewData_->currentPhrase_ + row_);
+                        param = phrase_->param2_ +
+                                (16 * viewData_->currentPhrase_ + row_);
+                    }
+                    if (*cmd == I_CMD_TABL) {
+                        viewData_->currentTable_ = (*param) & 0x7F;
+                    }
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+
+                if (mask & EPBM_UP) {
+
+                    // Go to groove view
+                    stopAudition();
+
+                    ViewType vt = VT_GROOVE;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
+                if (mask & EPBM_L)
+                    unMuteAll();
 
             } else {
-                // No modifier
-                
-    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-    			if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-    			if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
-    			}
+                // L Modifier
+                if (mask & EPBM_L) {
+
+                } else {
+                    // No modifier
+
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+                    if (mask & EPBM_START) {
+                        player->OnStartButton(PM_PHRASE, viewData_->songX_,
+                                              false, viewData_->chainRow_);
+                    }
+                }
             }
-		  }
-	  } 
-	    
-	}
-} ;
+        }
+    }
+};
 
 void PhraseView::processSelectionButtonMask(unsigned short mask) {
 
-	Player *player=Player::GetInstance() ;
+    Player *player = Player::GetInstance();
 
-	// B modifier
+    // B modifier
 
-	if (mask&EPBM_B) {
-        if (mask&EPBM_L) {
-          extendSelection() ;
+    if (mask & EPBM_B) {
+        if (mask & EPBM_L) {
+            extendSelection();
         } else {
-		  copySelection() ;
-       }
-	} else {
-        
-      // A Modifer
-      
-	  if (mask&EPBM_A) {
+            copySelection();
+        }
+    } else {
 
-		  if (mask&EPBM_DOWN) updateSelectionValue(VUD_DOWN) ;
-		  if (mask&EPBM_UP) updateSelectionValue(VUD_UP) ;
-		  if (mask&EPBM_LEFT) updateSelectionValue(VUD_LEFT) ;
-		  if (mask&EPBM_RIGHT) updateSelectionValue(VUD_RIGHT) ;
+        // A Modifer
 
-		if (mask&EPBM_L) cutSelection() ;
-		if (mask&EPBM_R) switchSoloMode() ;
-	  } else {
-            
-        // R Modifier
-        
-        if (mask&EPBM_R) {
-			if (mask&EPBM_LEFT) {
-					ViewType vt=VT_CHAIN ;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-			}
-			if (mask&EPBM_RIGHT) {
-				unsigned char *c=phrase_->instr_+(16*viewData_->currentPhrase_+row_) ;
-				if (*c!=0xFF) {
-					viewData_->currentInstrument_=*c ;
-				} else {
-					viewData_->currentInstrument_=lastInstr_ ;
-				}
-				ViewType vt=VT_INSTRUMENT ;
-				ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-				SetChanged();
-				NotifyObservers(&ve) ;
-			}
-    		if (mask&EPBM_START) {
-				player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
-    		}
-			if (mask&EPBM_L) unMuteAll() ;
+        if (mask & EPBM_A) {
 
-		} else {
-            // L Modifier
-            if (mask&EPBM_L) {
+            if (mask & EPBM_DOWN)
+                updateSelectionValue(VUD_DOWN);
+            if (mask & EPBM_UP)
+                updateSelectionValue(VUD_UP);
+            if (mask & EPBM_LEFT)
+                updateSelectionValue(VUD_LEFT);
+            if (mask & EPBM_RIGHT)
+                updateSelectionValue(VUD_RIGHT);
+
+            if (mask & EPBM_L)
+                cutSelection();
+            if (mask & EPBM_R)
+                switchSoloMode();
+        } else {
+
+            // R Modifier
+
+            if (mask & EPBM_R) {
+                if (mask & EPBM_LEFT) {
+                    ViewType vt = VT_CHAIN;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+                if (mask & EPBM_RIGHT) {
+                    unsigned char *c = phrase_->instr_ +
+                                       (16 * viewData_->currentPhrase_ + row_);
+                    if (*c != 0xFF) {
+                        viewData_->currentInstrument_ = *c;
+                    } else {
+                        viewData_->currentInstrument_ = lastInstr_;
+                    }
+                    ViewType vt = VT_INSTRUMENT;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
+                if (mask & EPBM_L)
+                    unMuteAll();
 
             } else {
-                // No modifier
-                
-    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-    			if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-    			if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
-    			}
+                // L Modifier
+                if (mask & EPBM_L) {
+
+                } else {
+                    // No modifier
+
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+                    if (mask & EPBM_START) {
+                        player->OnStartButton(PM_PHRASE, viewData_->songX_,
+                                              false, viewData_->chainRow_);
+                    }
+                }
             }
-		}
-	  } 
-	    
-	}
-} ;
-
-void PhraseView::setTextProps(GUITextProperties & props, int row,int col,bool restore) {
-
-	bool invert=false ;
-	
-	if (clipboard_.active_) {
-        GUIRect selRect=getSelectionRect() ;
-        if ((row>=selRect.Left())&&(row<=selRect.Right())&&
-            (col>=selRect.Top())&&(col<=selRect.Bottom())) {
-                invert=true ;
-        }        
-    } else {
-    	if ((col_==row)&&(row_==col)) {
-            invert=true ;
         }
     }
-    
+};
+
+void PhraseView::setTextProps(GUITextProperties &props, int row, int col,
+                              bool restore) {
+
+    bool invert = false;
+
+    if (clipboard_.active_) {
+        GUIRect selRect = getSelectionRect();
+        if ((row >= selRect.Left()) && (row <= selRect.Right()) &&
+            (col >= selRect.Top()) && (col <= selRect.Bottom())) {
+            invert = true;
+        }
+    } else {
+        if ((col_ == row) && (row_ == col)) {
+            invert = true;
+        }
+    }
+
     if (invert) {
         if (restore) {
-    		SetColor(CD_NORMAL) ;
-	   	    props.invert_=false;
+            SetColor(CD_NORMAL);
+            props.invert_ = false;
         } else {
-    		SetColor(CD_HILITE2) ;
-	   	    props.invert_=true;            
+            SetColor(CD_HILITE2);
+            props.invert_ = true;
         }
-	}
-} ;
+    }
+};
 
 void PhraseView::DrawView() {
 
-	Clear() ;
-	View::EnableNotification();
+    Clear();
+    View::EnableNotification();
 
-	GUITextProperties props ;
-	GUIPoint pos=GetTitlePosition() ;
+    GUITextProperties props;
+    GUIPoint pos = GetTitlePosition();
 
-// Draw title
+    // Draw title
 
-	char title[20] ;
+    char title[20];
 
-	SetColor(CD_NORMAL) ;
-	sprintf(title,"Phrase %2.2x",viewData_->currentPhrase_) ;
-	DrawString(pos._x,pos._y,title,props) ;
+    SetColor(CD_NORMAL);
+    sprintf(title, "Phrase %2.2x", viewData_->currentPhrase_);
+    DrawString(pos._x, pos._y, title, props);
 
-// Compute song grid location
+    // Compute song grid location
 
-	GUIPoint anchor=GetAnchor() ;
-	
-// Display row numbers
+    GUIPoint anchor = GetAnchor();
 
-	char buffer[6] ;
-	pos=anchor ;
-	pos._x-=3 ;
-	for (int j=0;j<16;j++) {
-		((j/altRowNumber_)%2)?SetColor(CD_ROW):SetColor(CD_ROW2);
-		hex2char(j,buffer) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-		pos._y++ ;
-	}
+    // Display row numbers
 
-	SetColor(CD_NORMAL) ;
+    char buffer[6];
+    pos = anchor;
+    pos._x -= 3;
+    for (int j = 0; j < 16; j++) {
+        ((j / altRowNumber_) % 2) ? SetColor(CD_ROW) : SetColor(CD_ROW2);
+        hex2char(j, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        pos._y++;
+    }
 
-	pos=anchor ;
+    SetColor(CD_NORMAL);
 
-// Display notes
+    pos = anchor;
 
-	unsigned char *data=phrase_->note_+(16*viewData_->currentPhrase_) ;
+    // Display notes
 
-	buffer[4]=0 ;
-	for (int j=0;j<16;j++) {
-		unsigned char d=*data++ ;
-        setTextProps(props,0,j,false) ;
-		(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL) ;
-		if (d==0xFF) {
-			DrawString(pos._x,pos._y,"----",props) ;
-		} else {
-            note2char(d,buffer) ;
-   			DrawString(pos._x,pos._y,buffer,props) ;
-		}
-        setTextProps(props,0,j,true) ;
-		pos._y++ ;
-	}
+    unsigned char *data = phrase_->note_ + (16 * viewData_->currentPhrase_);
 
-// Draw instruments
+    buffer[4] = 0;
+    for (int j = 0; j < 16; j++) {
+        unsigned char d = *data++;
+        setTextProps(props, 0, j, false);
+        (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                : SetColor(CD_NORMAL);
+        if (d == 0xFF) {
+            DrawString(pos._x, pos._y, "----", props);
+        } else {
+            note2char(d, buffer);
+            DrawString(pos._x, pos._y, buffer, props);
+        }
+        setTextProps(props, 0, j, true);
+        pos._y++;
+    }
 
-	pos=anchor ;
-	pos._x+=4 ;
-    
-	data=phrase_->instr_+(16*viewData_->currentPhrase_) ;
-	buffer[0]='I' ;
-    buffer[3]=0 ;
-    
-	for (int j=0;j<16;j++) {
-		unsigned char d=*data++ ;
-        setTextProps(props,1,j,false) ;
-		(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL);
-		if (d==0xFF) {
-			SetColor(CD_NORMAL) ;
-			DrawString(pos._x,pos._y,"I",props) ;
-			DrawString(pos._x+1,pos._y,"--",props) ;
-		} else {
-			hex2char(d,buffer+1) ;
-			DrawString(pos._x,pos._y,buffer,props) ;
-   			if (j==row_ && (col_ == 0 || col_ == 1)) {
-				SetColor(CD_NORMAL);
-                sprintf(buffer,"I%2.2x: ",d) ;
-				std::string instrLine=buffer ;
-                setTextProps(props,1,j,true) ;
-                GUIPoint location=GetTitlePosition() ;
-                location._x+=12 ;
-    	        InstrumentBank *bank=viewData_->project_->GetInstrumentBank() ;
-                I_Instrument *instr=bank->GetInstrument(d) ;
-				instrLine+=instr->GetName() ;
-				DrawString(location._x,location._y,instrLine.c_str(),props) ;
+    // Draw instruments
+
+    pos = anchor;
+    pos._x += 4;
+
+    data = phrase_->instr_ + (16 * viewData_->currentPhrase_);
+    buffer[0] = 'I';
+    buffer[3] = 0;
+
+    for (int j = 0; j < 16; j++) {
+        unsigned char d = *data++;
+        setTextProps(props, 1, j, false);
+        (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                : SetColor(CD_NORMAL);
+        if (d == 0xFF) {
+            SetColor(CD_NORMAL);
+            DrawString(pos._x, pos._y, "I", props);
+            DrawString(pos._x + 1, pos._y, "--", props);
+        } else {
+            hex2char(d, buffer + 1);
+            DrawString(pos._x, pos._y, buffer, props);
+            if (j == row_ && (col_ == 0 || col_ == 1)) {
+                SetColor(CD_NORMAL);
+                sprintf(buffer, "I%2.2x: ", d);
+                std::string instrLine = buffer;
+                setTextProps(props, 1, j, true);
+                GUIPoint location = GetTitlePosition();
+                location._x += 12;
+                InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
+                I_Instrument *instr = bank->GetInstrument(d);
+                instrLine += instr->GetName();
+                DrawString(location._x, location._y, instrLine.c_str(), props);
             }
-		}
-        setTextProps(props,1,j,true) ;
-		pos._y++ ;
-	}
-    
-// Draw command 1
+        }
+        setTextProps(props, 1, j, true);
+        pos._y++;
+    }
 
-	pos=anchor ;
-	pos._x+=8 ;
+    // Draw command 1
 
-	FourCC *f=phrase_->cmd1_+(16*viewData_->currentPhrase_) ;
+    pos = anchor;
+    pos._x += 8;
 
-	buffer[4]=0 ;
+    FourCC *f = phrase_->cmd1_ + (16 * viewData_->currentPhrase_);
 
-	for (int j=0;j<16;j++) {
-		FourCC command=*f++ ;
-		fourCC2char(command,buffer) ;
-        setTextProps(props,2,j,false) ;
-		(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL);
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,2,j,true) ;
-		pos._y++ ;
-		if (j == row_ && (col_ == 2 || col_ == 3)) {
-			printHelpLegend(command, props);
-		}
-	}
+    buffer[4] = 0;
 
+    for (int j = 0; j < 16; j++) {
+        FourCC command = *f++;
+        fourCC2char(command, buffer);
+        setTextProps(props, 2, j, false);
+        (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                : SetColor(CD_NORMAL);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 2, j, true);
+        pos._y++;
+        if (j == row_ && (col_ == 2 || col_ == 3)) {
+            printHelpLegend(command, props);
+        }
+    }
 
-// Draw commands params 1
+    // Draw commands params 1
 
-	pos=anchor ;
-	pos._x+=13 ;
+    pos = anchor;
+    pos._x += 13;
 
-	ushort *param=phrase_->param1_+(16*viewData_->currentPhrase_) ;
-	buffer[5]=0 ;
-	
-	for (int j=0;j<16;j++) {
-		ushort p=*param++ ;
-        setTextProps(props,3,j,false) ;
-/*		if (p==0xFFFF) {
-			DrawString(pos._x,pos._y,"----",props) ;
-		} else {
-*/			(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL);
-			hexshort2char(p,buffer) ;
-			DrawString(pos._x,pos._y,buffer,props) ;
-/*		}
-*/      setTextProps(props,3,j,true) ;
-		pos._y++ ;
-	}
-	
-// Draw commands 2
+    ushort *param = phrase_->param1_ + (16 * viewData_->currentPhrase_);
+    buffer[5] = 0;
 
-	pos=anchor ;
-	pos._x+=18 ;
+    for (int j = 0; j < 16; j++) {
+        ushort p = *param++;
+        setTextProps(props, 3, j, false);
+        /*		if (p==0xFFFF) {
+                    DrawString(pos._x,pos._y,"----",props) ;
+                } else {
+        */ (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                   : SetColor(CD_NORMAL);
+        hexshort2char(p, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        /*		}
+         */
+        setTextProps(props, 3, j, true);
+        pos._y++;
+    }
 
-	f=phrase_->cmd2_+(16*viewData_->currentPhrase_) ;
+    // Draw commands 2
 
-	buffer[4]=0 ;
+    pos = anchor;
+    pos._x += 18;
 
-	for (int j=0;j<16;j++) {
-		FourCC command=*f++ ;
-		fourCC2char(command,buffer) ;
-		(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL);
-        setTextProps(props,4,j,false) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,4,j,true) ;
-		pos._y++ ;
-		if (j == row_ &&(col_ == 4 || col_ == 5)) {
-			printHelpLegend(command, props);
-		}
-	}
+    f = phrase_->cmd2_ + (16 * viewData_->currentPhrase_);
 
-// Draw commands params
+    buffer[4] = 0;
 
-	pos=anchor ;
-	pos._x+=23 ;
+    for (int j = 0; j < 16; j++) {
+        FourCC command = *f++;
+        fourCC2char(command, buffer);
+        (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                : SetColor(CD_NORMAL);
+        setTextProps(props, 4, j, false);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 4, j, true);
+        pos._y++;
+        if (j == row_ && (col_ == 4 || col_ == 5)) {
+            printHelpLegend(command, props);
+        }
+    }
 
-	param=phrase_->param2_+(16*viewData_->currentPhrase_) ;
-	buffer[5]=0 ;
+    // Draw commands params
 
-	for (int j=0;j<16;j++) {
-		ushort p=*param++ ;
-        setTextProps(props,5,j,false) ;
-/*		if (p==0xFFFF) {
-			DrawString(pos._x,pos._y,"----",props) ;
-		} else {
-*/			(0==j||4==j||8==j||12==j)?SetColor(CD_MAJORBEAT):SetColor(CD_NORMAL);
-			hexshort2char(p,buffer) ;
-			DrawString(pos._x,pos._y,buffer,props) ;
-/*		}
-*/      setTextProps(props,5,j,true) ;
-		pos._y++ ;
-	}
+    pos = anchor;
+    pos._x += 23;
 
-    drawMap() ;
-   	drawNotes() ;
- 
-	Player *player=Player::GetInstance() ;
-	if (player->IsRunning()) {
-		OnPlayerUpdate(PET_UPDATE) ;
-	} ;
-	
-	if ((viewMode_!=VM_SELECTION)&&((col_==3)||(col_==5))) {
-		cmdEditField_->SetFocus() ;
-		cmdEditField_->Draw(w_) ;
-	} ;
-} ;
+    param = phrase_->param2_ + (16 * viewData_->currentPhrase_);
+    buffer[5] = 0;
 
-void PhraseView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
+    for (int j = 0; j < 16; j++) {
+        ushort p = *param++;
+        setTextProps(props, 5, j, false);
+        /*		if (p==0xFFFF) {
+                    DrawString(pos._x,pos._y,"----",props) ;
+                } else {
+        */ (0 == j || 4 == j || 8 == j || 12 == j) ? SetColor(CD_MAJORBEAT)
+                                                   : SetColor(CD_NORMAL);
+        hexshort2char(p, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        /*		}
+         */
+        setTextProps(props, 5, j, true);
+        pos._y++;
+    }
 
-    drawNotes() ;
-    
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint pos=anchor ;
-	pos._x-=1 ;
+    drawMap();
+    drawNotes();
 
-	GUITextProperties props ;
-	SetColor(CD_NORMAL) ;
+    Player *player = Player::GetInstance();
+    if (player->IsRunning()) {
+        OnPlayerUpdate(PET_UPDATE);
+    };
 
-	pos._y=anchor._y+lastPlayingPos_ ;
-	DrawString(pos._x,pos._y," ",props) ;
+    if ((viewMode_ != VM_SELECTION) && ((col_ == 3) || (col_ == 5))) {
+        cmdEditField_->SetFocus();
+        cmdEditField_->Draw(w_);
+    };
+};
 
-	Player *player=Player::GetInstance() ;
+void PhraseView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
-	if (eventType!=PET_STOP) {
+    drawNotes();
 
-		// Clear current position if needed
+    GUIPoint anchor = GetAnchor();
+    GUIPoint pos = anchor;
+    pos._x -= 1;
 
-		for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
+    GUITextProperties props;
+    SetColor(CD_NORMAL);
+
+    pos._y = anchor._y + lastPlayingPos_;
+    DrawString(pos._x, pos._y, " ", props);
+
+    Player *player = Player::GetInstance();
+
+    if (eventType != PET_STOP) {
+
+        // Clear current position if needed
+
+        for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
             if (player->IsChannelPlaying(i)) {
 
-    			if (viewData_->currentPlayPhrase_[i]==viewData_->currentPhrase_ &&
-		            viewData_->playMode_ != PM_AUDITION) {
-    				pos._y=anchor._y+viewData_->phrasePlayPos_[i] ;
+                if (viewData_->currentPlayPhrase_[i] ==
+                        viewData_->currentPhrase_ &&
+                    viewData_->playMode_ != PM_AUDITION) {
+                    pos._y = anchor._y + viewData_->phrasePlayPos_[i];
                     if (!player->IsChannelMuted(i)) {
-						SetColor(CD_PLAY);
-                        DrawString(pos._x,pos._y,">",props);
+                        SetColor(CD_PLAY);
+                        DrawString(pos._x, pos._y, ">", props);
                     } else {
                         SetColor(CD_MUTE);
-                        DrawString(pos._x,pos._y,"-",props);
+                        DrawString(pos._x, pos._y, "-", props);
                     }
-                    SetColor(CD_NORMAL);                    
-                    lastPlayingPos_=viewData_->phrasePlayPos_[i] ;
-                    break ;
-    			}
-    		}
+                    SetColor(CD_NORMAL);
+                    lastPlayingPos_ = viewData_->phrasePlayPos_[i];
+                    break;
+                }
+            }
         }
-        
-		// clear any live indicator
 
-		pos._y=anchor._y ;
-		DrawString(pos._x,pos._y," ",props) ;
+        // clear any live indicator
 
-		// Loop on all channels to see if one has queued current chain
-		if (player->GetSequencerMode()==SM_LIVE) {
+        pos._y = anchor._y;
+        DrawString(pos._x, pos._y, " ", props);
 
-			for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
-			   // is anything queued ?
-			   if (player->GetQueueingMode(i)!=QM_NONE) {
-				   // find the chain queued in channel
-					unsigned char songPos=player->GetQueuePosition(i) ;
-					unsigned char *chain=viewData_->song_->data_+i+8*songPos ;
-					if (*chain==viewData_->currentChain_) {
-						char *indicator=player->GetLiveIndicator(i) ;
-						DrawString(pos._x,pos._y,indicator,props) ;
-						break ;
-					}
-			   }
-			}
-		}
-	}
+        // Loop on all channels to see if one has queued current chain
+        if (player->GetSequencerMode() == SM_LIVE) {
 
-    pos=anchor ;
-    pos._x+=200 ;
-
-/*	if (player->Clipped()) {
-           w_.DrawString("clip",pos,props); 
-    } else {
-           w_.DrawString("----",pos,props); 
+            for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+                // is anything queued ?
+                if (player->GetQueueingMode(i) != QM_NONE) {
+                    // find the chain queued in channel
+                    unsigned char songPos = player->GetQueuePosition(i);
+                    unsigned char *chain =
+                        viewData_->song_->data_ + i + 8 * songPos;
+                    if (*chain == viewData_->currentChain_) {
+                        char *indicator = player->GetLiveIndicator(i);
+                        DrawString(pos._x, pos._y, indicator, props);
+                        break;
+                    }
+                }
+            }
+        }
     }
-*/
-} ;
+
+    pos = anchor;
+    pos._x += 200;
+
+    /*	if (player->Clipped()) {
+               w_.DrawString("clip",pos,props);
+        } else {
+               w_.DrawString("----",pos,props);
+        }
+    */
+};
 
 void PhraseView::printHelpLegend(FourCC command, GUITextProperties props) {
-	SetColor(CD_NORMAL);
-	std::string* cmdStr = getHelpLegend(command);
-	DrawString(10, 0, cmdStr[0].c_str(), props);
-	DrawString(10, 1, cmdStr[1].c_str(), props);
-	DrawString(10, 2, cmdStr[2].c_str(), props);
+    SetColor(CD_NORMAL);
+    std::string *cmdStr = getHelpLegend(command);
+    DrawString(10, 0, cmdStr[0].c_str(), props);
+    DrawString(10, 1, cmdStr[1].c_str(), props);
+    DrawString(10, 2, cmdStr[2].c_str(), props);
 }

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1238,15 +1238,16 @@ void PhraseView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
     			if (viewData_->currentPlayPhrase_[i]==viewData_->currentPhrase_ &&
 		            viewData_->playMode_ != PM_AUDITION) {
     				pos._y=anchor._y+viewData_->phrasePlayPos_[i] ;
-    				if (!player->IsChannelMuted(i)) {
-						SetColor(CD_CURSOR) ;
-						DrawString(pos._x,pos._y,">",props) ;
-						SetColor(CD_NORMAL) ;
-    				} else {
-    					DrawString(pos._x,pos._y,"-",props) ;
-    				}
-    				lastPlayingPos_=viewData_->phrasePlayPos_[i] ;
-    				break ;
+                    if (!player->IsChannelMuted(i)) {
+						SetColor(CD_PLAY);
+                        DrawString(pos._x,pos._y,">",props);
+                    } else {
+                        SetColor(CD_MUTE);
+                        DrawString(pos._x,pos._y,"-",props);
+                    }
+                    SetColor(CD_NORMAL);                    
+                    lastPlayingPos_=viewData_->phrasePlayPos_[i] ;
+                    break ;
     			}
     		}
         }

--- a/sources/Application/Views/PhraseView.h
+++ b/sources/Application/Views/PhraseView.h
@@ -6,77 +6,77 @@
 #include "BaseClasses/View.h"
 #include "ViewData.h"
 
-#define FCC_EDIT MAKE_FOURCC('V','O','L','M')
+#define FCC_EDIT MAKE_FOURCC('V', 'O', 'L', 'M')
 
-class PhraseView: public View {
+class PhraseView : public View {
 
-public:
+  public:
+    PhraseView(GUIWindow &w, ViewData *viewData);
+    ~PhraseView();
+    virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+    virtual void DrawView();
+    virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
+    virtual void OnFocus();
 
-	PhraseView(GUIWindow &w,ViewData *viewData) ;
-	~PhraseView() ;
-	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
-	virtual void DrawView() ;
-	virtual void OnPlayerUpdate(PlayerEventType ,unsigned int tick=0) ;
-	virtual void OnFocus() ;
-protected:
-	void updateCursor(int dx,int dy) ;
-	void stopAudition();
-	void updateCursorValue(ViewUpdateDirection offset,int xOffset=0,int yOffset=0) ;
-	void updateSelectionValue(ViewUpdateDirection direction) ;
-	void warpToNeighbour(int offset) ;
-	void warpInChain(int offset) ;
-	void cutPosition() ;
-	void pasteLast() ;
+  protected:
+    void updateCursor(int dx, int dy);
+    void stopAudition();
+    void updateCursorValue(ViewUpdateDirection offset, int xOffset = 0,
+                           int yOffset = 0);
+    void updateSelectionValue(ViewUpdateDirection direction);
+    void warpToNeighbour(int offset);
+    void warpInChain(int offset);
+    void cutPosition();
+    void pasteLast();
 
-    void extendSelection() ;
-    
-	GUIRect getSelectionRect() ;
-	void fillClipboardData() ;
-	void copySelection() ;
-	void cutSelection() ;
-	void pasteClipboard() ;
+    void extendSelection();
 
-	void unMuteAll() ;
-	void toggleMute() ;
-	void switchSoloMode() ;
+    GUIRect getSelectionRect();
+    void fillClipboardData();
+    void copySelection();
+    void cutSelection();
+    void pasteClipboard();
 
-	void processNormalButtonMask(unsigned short mask) ;
-	void processSelectionButtonMask(unsigned short mask) ;
+    void unMuteAll();
+    void toggleMute();
+    void switchSoloMode();
 
-    void setTextProps(GUITextProperties & props, int row,int col,bool restore) ;
+    void processNormalButtonMask(unsigned short mask);
+    void processSelectionButtonMask(unsigned short mask);
 
-private:
+    void setTextProps(GUITextProperties &props, int row, int col, bool restore);
 
-	int row_ ;
-	int col_ ;
-	int lastNote_ ;
-	int lastInstr_ ;
-	int lastCmd_ ;
-	int lastParam_ ;
-	Phrase *phrase_ ;
-	int lastPlayingPos_ ;
-	Variable cmdEdit_ ;
-	UIBigHexVarField *cmdEditField_ ;
-	void printHelpLegend(FourCC command, GUITextProperties props);
+  private:
+    int row_;
+    int col_;
+    int lastNote_;
+    int lastInstr_;
+    int lastCmd_;
+    int lastParam_;
+    Phrase *phrase_;
+    int lastPlayingPos_;
+    Variable cmdEdit_;
+    UIBigHexVarField *cmdEditField_;
+    void printHelpLegend(FourCC command, GUITextProperties props);
 
-	struct clipboard {
-		bool active_ ;
-		int col_ ;
-		int row_ ;
-		int width_ ;
-		int height_ ;
-		uchar note_[16] ;
-		uchar instr_[16] ;
-		uint cmd1_[16] ;
- 		ushort param1_[16] ;
-		uint cmd2_[16] ;
- 		ushort param2_[16] ;
-	} clipboard_ ;
+    struct clipboard {
+        bool active_;
+        int col_;
+        int row_;
+        int width_;
+        int height_;
+        uchar note_[16];
+        uchar instr_[16];
+        uint cmd1_[16];
+        ushort param1_[16];
+        uint cmd2_[16];
+        ushort param2_[16];
+    } clipboard_;
 
-	int saveCol_ ;
-	int saveRow_ ;
+    int saveCol_;
+    int saveRow_;
 
-	static short offsets_[2][4] ;
-} ;
+    static short offsets_[2][4];
+};
 
 #endif

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1,83 +1,84 @@
 #include "SongView.h"
+#include "Application/Commands/ApplicationCommandDispatcher.h"
+#include "Application/Player/Player.h"
+#include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
-#include "Application/Utils/char.h"
-#include "Application/Player/Player.h"
-#include "UIController.h" 
-#include "Application/Commands/ApplicationCommandDispatcher.h"
-#include <stdlib.h>
-#include <string>
+#include "UIController.h"
 #include <iostream>
 #include <sstream>
+#include <stdlib.h>
+#include <string>
 
 /****************
  Constructor
  ****************/
- 
-SongView::SongView(GUIWindow &w,ViewData *viewData,const char *song):View(w,viewData) {
 
-	updatingChain_=false ;
-	lastChain_=0 ;
-	songname_=song ;
+SongView::SongView(GUIWindow &w, ViewData *viewData, const char *song)
+    : View(w, viewData) {
 
-	for (int i=0;i<8;i++) {
-		this->lastPlayedPosition_[i]=0 ;
-		this->lastQueuedPosition_[i]=0 ;
-	}
-	clipboard_.active_=false ;
-	clipboard_.data_=0 ;
-	invertBatt_=false ;
-	canDeepClone_ = false;
-	jumpLength_ = 0x10; // B-jump 16 rows like LSDJ
+    updatingChain_ = false;
+    lastChain_ = 0;
+    songname_ = song;
+
+    for (int i = 0; i < 8; i++) {
+        this->lastPlayedPosition_[i] = 0;
+        this->lastQueuedPosition_[i] = 0;
+    }
+    clipboard_.active_ = false;
+    clipboard_.data_ = 0;
+    invertBatt_ = false;
+    canDeepClone_ = false;
+    jumpLength_ = 0x10; // B-jump 16 rows like LSDJ
 }
 
 /****************
  Destructor
  ****************/
-  
+
 SongView::~SongView() {
-    if (clipboard_.data_!=0) SYS_FREE((void *)clipboard_.data_) ;
-} ;
+    if (clipboard_.data_ != 0)
+        SYS_FREE((void *)clipboard_.data_);
+};
 
 /******************************************************
  updateChain:
         update current chain value by adding offset
         parameter
  ******************************************************/
- 
+
 void SongView::updateChain(int offset) {
 
-	unsigned int chain=viewData_->UpdateSongChain(offset) ;
-	updatingChain_=true ;
-	lastChain_=chain ;
-	updateX_=viewData_->songX_ ;
-	updateY_=viewData_->songY_ ;
-	isDirty_=true ;
-	canDeepClone_ = false;
+    unsigned int chain = viewData_->UpdateSongChain(offset);
+    updatingChain_ = true;
+    lastChain_ = chain;
+    updateX_ = viewData_->songX_;
+    updateY_ = viewData_->songY_;
+    isDirty_ = true;
+    canDeepClone_ = false;
 }
-
 
 /******************************************************
  updateChain:
         set current chain value to value parameter
  ******************************************************/
- 
+
 void SongView::setChain(unsigned char value) {
-	viewData_->SetSongChain(value) ;
-	lastChain_=value ;
-	isDirty_=true ;
+    viewData_->SetSongChain(value);
+    lastChain_ = value;
+    isDirty_ = true;
 }
 
 /******************************************************
  updateSongOffset:
         Jump from the current position up or down
-	by [offset] rows
+    by [offset] rows
  ******************************************************/
- 
+
 void SongView::updateSongOffset(int offset) {
-	viewData_->UpdateSongOffset(offset) ;
-	isDirty_=true ;
-	canDeepClone_ = false;
+    viewData_->UpdateSongOffset(offset);
+    isDirty_ = true;
+    canDeepClone_ = false;
 }
 
 /******************************************************
@@ -85,11 +86,11 @@ void SongView::updateSongOffset(int offset) {
         modify location of cursor in view by
         adding dx & dy parameters
  ******************************************************/
- 
-void SongView::updateCursor(int dx,int dy) {
-	viewData_->UpdateSongCursor(dx,dy) ;
-	isDirty_=true ;
-	canDeepClone_ = false;
+
+void SongView::updateCursor(int dx, int dy) {
+    viewData_->UpdateSongCursor(dx, dy);
+    isDirty_ = true;
+    canDeepClone_ = false;
 }
 
 /******************************************************
@@ -97,461 +98,469 @@ void SongView::updateCursor(int dx,int dy) {
         copy current position content to clipboard &
         erase current position value
  ******************************************************/
- 
+
 void SongView::cutPosition() {
 
     // prepare selection data
-    clipboard_.x_=viewData_->songX_ ;
-    clipboard_.y_=viewData_->songY_ ;
-    clipboard_.offset_=viewData_->songOffset_ ;
+    clipboard_.x_ = viewData_->songX_;
+    clipboard_.y_ = viewData_->songY_;
+    clipboard_.offset_ = viewData_->songOffset_;
 
-    saveX_=viewData_->songX_ ;
-    saveY_=viewData_->songY_ ;
-    saveOffset_=viewData_->songOffset_ ;
+    saveX_ = viewData_->songX_;
+    saveY_ = viewData_->songY_;
+    saveOffset_ = viewData_->songOffset_;
 
     // cut selection
-    cutSelection() ;
-} ;
+    cutSelection();
+};
 
 /******************************************************
  pastePosition:
         set current position to last chain value if
         current step is empty
  ******************************************************/
- 
- void SongView::pasteLast() {
 
-	 // If we're on an empty spot, we past the last chain
-	 // otherwise we take the current chain as last
+void SongView::pasteLast() {
 
-    unsigned char *c=viewData_->GetCurrentSongPointer() ;
-	if (*c==0xFF) {
-		*c=lastChain_ ;
-		viewData_->song_->chain_->SetUsed(*c) ;
-		isDirty_=true ;
-	} else {
-		lastChain_=*c ;
-	}
-} ;
+    // If we're on an empty spot, we past the last chain
+    // otherwise we take the current chain as last
+
+    unsigned char *c = viewData_->GetCurrentSongPointer();
+    if (*c == 0xFF) {
+        *c = lastChain_;
+        viewData_->song_->chain_->SetUsed(*c);
+        isDirty_ = true;
+    } else {
+        lastChain_ = *c;
+    }
+};
 
 /******************************************************
  clonePosition:
         slim clone current position
  ******************************************************/
- 
+
 void SongView::clonePosition() {
 
+    unsigned char *pos = viewData_->GetCurrentSongPointer();
+    unsigned char current = *pos;
+    if (current == 255)
+        return;
 
-    unsigned char *pos=viewData_->GetCurrentSongPointer() ;
-    unsigned char current=*pos ;
-	if (current==255) return;
-    
-	unsigned short next=viewData_->song_->chain_->GetNext() ;
-	if (next==NO_MORE_CHAIN) return ;
-    
-    unsigned char *src=viewData_->song_->chain_->data_+16*current ;
-    unsigned char *dst=viewData_->song_->chain_->data_+16*next ;
+    unsigned short next = viewData_->song_->chain_->GetNext();
+    if (next == NO_MORE_CHAIN)
+        return;
 
-    for (int i=0;i<16;i++) {
-        *dst++=*src++ ;
-    } ;
+    unsigned char *src = viewData_->song_->chain_->data_ + 16 * current;
+    unsigned char *dst = viewData_->song_->chain_->data_ + 16 * next;
 
-    src=viewData_->song_->chain_->transpose_+16*current ;
-    dst=viewData_->song_->chain_->transpose_+16*next ;
-    
-    for (int i=0;i<16;i++) {
-        *dst++=*src++ ;
-    } ;
-    setChain((unsigned char)next) ;
-    isDirty_=true ;
-} ;
+    for (int i = 0; i < 16; i++) {
+        *dst++ = *src++;
+    };
+
+    src = viewData_->song_->chain_->transpose_ + 16 * current;
+    dst = viewData_->song_->chain_->transpose_ + 16 * next;
+
+    for (int i = 0; i < 16; i++) {
+        *dst++ = *src++;
+    };
+    setChain((unsigned char)next);
+    isDirty_ = true;
+};
 
 /******************************************************
  deepClonePosition:
         deep clone chain and all phrases within
-		made by koisignal (https://github.com/koi-ikeno)
+        made by koisignal (https://github.com/koi-ikeno)
  ******************************************************/
- 
+
 void SongView::deepClonePosition() {
-	Phrase *ph = viewData_->song_->phrase_;
-	Chain *ch = viewData_->song_->chain_;
-	unsigned char *pos = viewData_->GetCurrentSongPointer();
-	unsigned char curChainNum = *pos;
+    Phrase *ph = viewData_->song_->phrase_;
+    Chain *ch = viewData_->song_->chain_;
+    unsigned char *pos = viewData_->GetCurrentSongPointer();
+    unsigned char curChainNum = *pos;
 
-	if (curChainNum == CHAIN_COUNT) {
-		View::SetNotification("no more chains!");
-		return;
-	}
+    if (curChainNum == CHAIN_COUNT) {
+        View::SetNotification("no more chains!");
+        return;
+    }
 
-	unsigned char *srcChain = ch->data_ + 16 * curChainNum;
-	unsigned char *dstChain = ch->data_ + 16 * curChainNum;
-	unsigned short srcPhrases[16];
-	unsigned short dstPhrases[16];
+    unsigned char *srcChain = ch->data_ + 16 * curChainNum;
+    unsigned char *dstChain = ch->data_ + 16 * curChainNum;
+    unsigned short srcPhrases[16];
+    unsigned short dstPhrases[16];
 
-	// Init outside valid range
-	for (int i = 0; i < 16; i++) {
-		srcPhrases[i] = NO_MORE_CHAIN;
-		dstPhrases[i] = NO_MORE_CHAIN;
-	}
+    // Init outside valid range
+    for (int i = 0; i < 16; i++) {
+        srcPhrases[i] = NO_MORE_CHAIN;
+        dstPhrases[i] = NO_MORE_CHAIN;
+    }
 
-	for (int i = 0; i < 16; i++) {
-		unsigned short srcPhraseNum = *srcChain;
-		
-		// skip when "--"
-		if (srcPhraseNum == CHAIN_COUNT) {
-			srcChain++;
-			dstChain++;
-			continue;
-		}
+    for (int i = 0; i < 16; i++) {
+        unsigned short srcPhraseNum = *srcChain;
 
-		unsigned short newPhraseNum = NO_MORE_CHAIN;
+        // skip when "--"
+        if (srcPhraseNum == CHAIN_COUNT) {
+            srcChain++;
+            dstChain++;
+            continue;
+        }
 
-		for (int j = 0; j < 16; j++) {
-			if (srcPhrases[j] == srcPhraseNum) {
-				newPhraseNum = dstPhrases[j];
-				break;
-			}
-		}
-		
-		if (newPhraseNum == NO_MORE_CHAIN)
-		{
-			newPhraseNum = ph->GetNext();
-			if (newPhraseNum == NO_MORE_PHRASE) {
-				View::SetNotification("no more phrases!");
-				return;
-			}
-			for (int k = 0; k < 16; k++) {
-				*(ph->note_ + 16 * newPhraseNum + k)
-					= *(ph->note_ + 16 * srcPhraseNum + k);
-				*(ph->instr_ + 16 * newPhraseNum + k)
-					= *(ph->instr_ + 16 * srcPhraseNum + k);
-				*(ph->cmd1_ + 16 * newPhraseNum + k)
-					= *(ph->cmd1_ + 16 * srcPhraseNum + k);
-				*(ph->cmd2_ + 16 * newPhraseNum + k)
-					= *(ph->cmd2_ + 16 * srcPhraseNum + k);
-				*(ph->param1_ + 16 * newPhraseNum + k)
-					= *(ph->param1_ + 16 * srcPhraseNum + k);
-				*(ph->param2_ + 16 * newPhraseNum + k)
-					= *(ph->param2_ + 16 * srcPhraseNum + k);
-			}
-		}
-		srcPhrases[i] = srcPhraseNum;
-		dstPhrases[i] = newPhraseNum;
-		*dstChain = newPhraseNum;
-		srcChain++;
-		dstChain++;
-	}
-	View::SetNotification("deep clone");
+        unsigned short newPhraseNum = NO_MORE_CHAIN;
 
-	setChain((unsigned char) curChainNum);
+        for (int j = 0; j < 16; j++) {
+            if (srcPhrases[j] == srcPhraseNum) {
+                newPhraseNum = dstPhrases[j];
+                break;
+            }
+        }
+
+        if (newPhraseNum == NO_MORE_CHAIN) {
+            newPhraseNum = ph->GetNext();
+            if (newPhraseNum == NO_MORE_PHRASE) {
+                View::SetNotification("no more phrases!");
+                return;
+            }
+            for (int k = 0; k < 16; k++) {
+                *(ph->note_ + 16 * newPhraseNum + k) =
+                    *(ph->note_ + 16 * srcPhraseNum + k);
+                *(ph->instr_ + 16 * newPhraseNum + k) =
+                    *(ph->instr_ + 16 * srcPhraseNum + k);
+                *(ph->cmd1_ + 16 * newPhraseNum + k) =
+                    *(ph->cmd1_ + 16 * srcPhraseNum + k);
+                *(ph->cmd2_ + 16 * newPhraseNum + k) =
+                    *(ph->cmd2_ + 16 * srcPhraseNum + k);
+                *(ph->param1_ + 16 * newPhraseNum + k) =
+                    *(ph->param1_ + 16 * srcPhraseNum + k);
+                *(ph->param2_ + 16 * newPhraseNum + k) =
+                    *(ph->param2_ + 16 * srcPhraseNum + k);
+            }
+        }
+        srcPhrases[i] = srcPhraseNum;
+        dstPhrases[i] = newPhraseNum;
+        *dstChain = newPhraseNum;
+        srcChain++;
+        dstChain++;
+    }
+    View::SetNotification("deep clone");
+
+    setChain((unsigned char)curChainNum);
 }
 
 void SongView::extendSelection() {
-	GUIRect rect=getSelectionRect() ;
-	if (rect.Left()>0||rect.Right()<7) {
-		if (viewData_->songX_<clipboard_.x_) {
-			viewData_->songX_=0 ;
-			clipboard_.x_=7 ;
-		} else {
-			viewData_->songX_=7 ;
-			clipboard_.x_=0 ;
-		}
-		isDirty_=true ;
-	} else {
-		if (viewData_->songY_<clipboard_.y_) {
-			viewData_->songY_=0 ;
-			clipboard_.y_=0x17 ;
-		} else {
-			clipboard_.y_=0 ;
-			viewData_->songY_=0x17 ;
-		}
-		isDirty_=true ;
-	}
+    GUIRect rect = getSelectionRect();
+    if (rect.Left() > 0 || rect.Right() < 7) {
+        if (viewData_->songX_ < clipboard_.x_) {
+            viewData_->songX_ = 0;
+            clipboard_.x_ = 7;
+        } else {
+            viewData_->songX_ = 7;
+            clipboard_.x_ = 0;
+        }
+        isDirty_ = true;
+    } else {
+        if (viewData_->songY_ < clipboard_.y_) {
+            viewData_->songY_ = 0;
+            clipboard_.y_ = 0x17;
+        } else {
+            clipboard_.y_ = 0;
+            viewData_->songY_ = 0x17;
+        }
+        isDirty_ = true;
+    }
 }
 
 /******************************************************
  OnFocus:
         called when current view is becoming active
  ******************************************************/
- 
-void SongView::OnFocus() {
-    clipboard_.active_=false ;
-} ;
+
+void SongView::OnFocus() { clipboard_.active_ = false; };
 
 GUIRect SongView::getSelectionRect() {
-    
-    GUIRect selRect(clipboard_.x_,clipboard_.y_+clipboard_.offset_,
-                    viewData_->songX_,viewData_->songY_+viewData_->songOffset_) ;
-                    
-    selRect.Normalize() ;        
-    return selRect ;
 
-}    
+    GUIRect selRect(clipboard_.x_, clipboard_.y_ + clipboard_.offset_,
+                    viewData_->songX_,
+                    viewData_->songY_ + viewData_->songOffset_);
+
+    selRect.Normalize();
+    return selRect;
+}
 
 /******************************************************
  fillClipboard:
         fill clipboard with current selection value
  ******************************************************/
- 
+
 void SongView::fillClipboardData() {
-    
+
     // Clear current selection data
-    
-    if (!clipboard_.data_) SYS_FREE((void *)clipboard_.data_) ;
-    
+
+    if (!clipboard_.data_)
+        SYS_FREE((void *)clipboard_.data_);
+
     // Prepare selection related information
 
-    GUIRect selRect=getSelectionRect() ;
-    
-    // Set current selection  data
-    
-    clipboard_.width_=selRect.Width()+1 ;
-    clipboard_.height_=selRect.Height()+1 ;
-    
-    clipboard_.data_=(unsigned char *)SYS_MALLOC(clipboard_.width_*clipboard_.height_) ;
-  
-    unsigned char *src=viewData_->song_->data_+selRect.Left()+SONG_CHANNEL_COUNT*selRect.Top() ;  
-    unsigned char *dst=clipboard_.data_ ;
+    GUIRect selRect = getSelectionRect();
 
-    for (int j=0;j<clipboard_.height_;j++) {
-        for (int i=0;i<clipboard_.width_;i++) {
-            *dst++=*src++ ;
+    // Set current selection  data
+
+    clipboard_.width_ = selRect.Width() + 1;
+    clipboard_.height_ = selRect.Height() + 1;
+
+    clipboard_.data_ =
+        (unsigned char *)SYS_MALLOC(clipboard_.width_ * clipboard_.height_);
+
+    unsigned char *src = viewData_->song_->data_ + selRect.Left() +
+                         SONG_CHANNEL_COUNT * selRect.Top();
+    unsigned char *dst = clipboard_.data_;
+
+    for (int j = 0; j < clipboard_.height_; j++) {
+        for (int i = 0; i < clipboard_.width_; i++) {
+            *dst++ = *src++;
         }
-        src+=(SONG_CHANNEL_COUNT-clipboard_.width_) ;
+        src += (SONG_CHANNEL_COUNT - clipboard_.width_);
     }
-} ;
+};
 
 /******************************************************
  copySelection:
         copy current selection to clipboard
  ******************************************************/
- 
+
 void SongView::copySelection() {
-    
-    fillClipboardData() ;
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    viewData_->songX_=saveX_ ;
-    viewData_->songY_=saveY_ ;
-    viewData_->songOffset_=saveOffset_ ;
-	View::SetNotification("copied selection");
+
+    fillClipboardData();
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    viewData_->songX_ = saveX_;
+    viewData_->songY_ = saveY_;
+    viewData_->songOffset_ = saveOffset_;
+    View::SetNotification("copied selection");
 }
 
 /******************************************************
  cutSelection:
         cut current selection to clipboard
  ******************************************************/
- 
-void SongView::cutSelection() {
-    
-    // first copy the data to clipboard
-    
-    fillClipboardData() ;
-    GUIRect selRect=getSelectionRect() ;
-    
-    // now move all rows up for cut
-    
-    unsigned char *dst=viewData_->song_->data_+selRect.Left()+SONG_CHANNEL_COUNT*(selRect.Top()) ;  
-    unsigned char *src=dst+SONG_CHANNEL_COUNT*clipboard_.height_ ;
-    
-    int rowCount=SONG_ROW_COUNT-selRect.Bottom()-1 ;
-    
-    for (int j=0;j<rowCount;j++) {
-        
-        for (int i=0;i<clipboard_.width_;i++) {
-            *dst++=*src++ ;
-        }
-        src+=(SONG_CHANNEL_COUNT-clipboard_.width_) ;
-        dst+=(SONG_CHANNEL_COUNT-clipboard_.width_) ;
-    }
-    
-    for (int j=0;j>clipboard_.height_;j++) {
-        for (int i=0;i<clipboard_.width_;i++) {
-            *dst++=0xFF ;
-        }        
-        dst+=(SONG_CHANNEL_COUNT-clipboard_.width_) ;
-    } ;
-    
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    viewData_->songX_=saveX_ ;
-    viewData_->songY_=saveY_ ;
-    viewData_->songOffset_=saveOffset_ ;
 
-    isDirty_=true ;    
+void SongView::cutSelection() {
+
+    // first copy the data to clipboard
+
+    fillClipboardData();
+    GUIRect selRect = getSelectionRect();
+
+    // now move all rows up for cut
+
+    unsigned char *dst = viewData_->song_->data_ + selRect.Left() +
+                         SONG_CHANNEL_COUNT * (selRect.Top());
+    unsigned char *src = dst + SONG_CHANNEL_COUNT * clipboard_.height_;
+
+    int rowCount = SONG_ROW_COUNT - selRect.Bottom() - 1;
+
+    for (int j = 0; j < rowCount; j++) {
+
+        for (int i = 0; i < clipboard_.width_; i++) {
+            *dst++ = *src++;
+        }
+        src += (SONG_CHANNEL_COUNT - clipboard_.width_);
+        dst += (SONG_CHANNEL_COUNT - clipboard_.width_);
+    }
+
+    for (int j = 0; j > clipboard_.height_; j++) {
+        for (int i = 0; i < clipboard_.width_; i++) {
+            *dst++ = 0xFF;
+        }
+        dst += (SONG_CHANNEL_COUNT - clipboard_.width_);
+    };
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    viewData_->songX_ = saveX_;
+    viewData_->songY_ = saveY_;
+    viewData_->songOffset_ = saveOffset_;
+
+    isDirty_ = true;
 }
 
 /******************************************************
  pasteSelection:
         paste clipboard content to song
  ******************************************************/
- 
- void SongView::pasteClipboard() {
 
-	if (!clipboard_.data_) return ;
-	
-  // Check we're not out of scope
+void SongView::pasteClipboard() {
 
-    int width=clipboard_.width_ ;
-    int height=clipboard_.height_ ;
-    
-    if (viewData_->songX_+width>SONG_CHANNEL_COUNT) {
-        width=SONG_CHANNEL_COUNT-viewData_->songX_ ;
+    if (!clipboard_.data_)
+        return;
+
+    // Check we're not out of scope
+
+    int width = clipboard_.width_;
+    int height = clipboard_.height_;
+
+    if (viewData_->songX_ + width > SONG_CHANNEL_COUNT) {
+        width = SONG_CHANNEL_COUNT - viewData_->songX_;
     }
-    if (viewData_->songY_+viewData_->songOffset_+height>SONG_ROW_COUNT) {
-        height=SONG_ROW_COUNT-viewData_->songY_-viewData_->songOffset_ ;
-    } else {   
+    if (viewData_->songY_ + viewData_->songOffset_ + height > SONG_ROW_COUNT) {
+        height = SONG_ROW_COUNT - viewData_->songY_ - viewData_->songOffset_;
+    } else {
 
-      // Move down from insert point
-  
-      unsigned char *dst=viewData_->song_->data_+viewData_->songX_+(SONG_ROW_COUNT-1)*SONG_CHANNEL_COUNT ;    
-      unsigned char *src=dst-height*SONG_CHANNEL_COUNT ;
-    
-      int rowCount=SONG_ROW_COUNT-(viewData_->songY_+viewData_->songOffset_) ;
+        // Move down from insert point
 
-      for (int j=0;j<rowCount;j++) {
-        for (int i=0;i<width;i++) {
-            *dst++=*src++ ;
+        unsigned char *dst = viewData_->song_->data_ + viewData_->songX_ +
+                             (SONG_ROW_COUNT - 1) * SONG_CHANNEL_COUNT;
+        unsigned char *src = dst - height * SONG_CHANNEL_COUNT;
+
+        int rowCount =
+            SONG_ROW_COUNT - (viewData_->songY_ + viewData_->songOffset_);
+
+        for (int j = 0; j < rowCount; j++) {
+            for (int i = 0; i < width; i++) {
+                *dst++ = *src++;
+            }
+            dst -= (SONG_CHANNEL_COUNT + width);
+            src -= (SONG_CHANNEL_COUNT + width);
         }
-        dst-=(SONG_CHANNEL_COUNT+width) ;
-        src-=(SONG_CHANNEL_COUNT+width) ;
-      }
     }
-    
+
     // Prepare copy pointer
-          
-    unsigned char *dst=viewData_->GetCurrentSongPointer() ;  
-    unsigned char *src=clipboard_.data_ ;
-    
-    for (int j=0;j<height;j++) {
-      for (int i=0;i<width;i++) {
-          *dst++=*src++ ;
-      }
-      dst+=(SONG_CHANNEL_COUNT-width) ;
-      src+=(clipboard_.width_-width) ;
+
+    unsigned char *dst = viewData_->GetCurrentSongPointer();
+    unsigned char *src = clipboard_.data_;
+
+    for (int j = 0; j < height; j++) {
+        for (int i = 0; i < width; i++) {
+            *dst++ = *src++;
+        }
+        dst += (SONG_CHANNEL_COUNT - width);
+        src += (clipboard_.width_ - width);
     }
-    
-    updateCursor(0,height) ;        
+
+    updateCursor(0, height);
 }
 
 void SongView::unMuteAll() {
 
-	UIController *controller=UIController::GetInstance() ;
-	controller->UnMuteAll() ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    controller->UnMuteAll();
+};
 
 void SongView::toggleMute() {
 
-	UIController *controller=UIController::GetInstance() ;
+    UIController *controller = UIController::GetInstance();
 
-	int from=viewData_->songX_ ;
-	int to=from ;
-	if (clipboard_.active_) {
-		GUIRect r=getSelectionRect() ;
-		from=r.Left() ;
-		to=r.Right() ;
-	} ;
-	controller->ToggleMute(from,to) ;
-	viewMode_=(viewMode_!=VM_MUTEON)?VM_MUTEON:VM_NORMAL ;
-} ;
+    int from = viewData_->songX_;
+    int to = from;
+    if (clipboard_.active_) {
+        GUIRect r = getSelectionRect();
+        from = r.Left();
+        to = r.Right();
+    };
+    controller->ToggleMute(from, to);
+    viewMode_ = (viewMode_ != VM_MUTEON) ? VM_MUTEON : VM_NORMAL;
+};
 
 void SongView::switchSoloMode() {
 
-	UIController *controller=UIController::GetInstance() ;
-	int from=viewData_->songX_ ;
-	int to=from ;
-	if (clipboard_.active_) {
-		GUIRect r=getSelectionRect() ;
-		from=r.Left() ;
-		to=r.Right() ;
-	} ;
-	controller->SwitchSoloMode(from,to,(viewMode_!=VM_SOLOON)) ;
-	viewMode_=(viewMode_!=VM_SOLOON)?VM_SOLOON:VM_NORMAL ;
-    isDirty_=true ;
-} ;
+    UIController *controller = UIController::GetInstance();
+    int from = viewData_->songX_;
+    int to = from;
+    if (clipboard_.active_) {
+        GUIRect r = getSelectionRect();
+        from = r.Left();
+        to = r.Right();
+    };
+    controller->SwitchSoloMode(from, to, (viewMode_ != VM_SOLOON));
+    viewMode_ = (viewMode_ != VM_SOLOON) ? VM_SOLOON : VM_NORMAL;
+    isDirty_ = true;
+};
 
 void SongView::onStart() {
-	Player *player=Player::GetInstance() ;
-	unsigned char from=viewData_->songX_ ;
-	unsigned char to=from ;
-	if (clipboard_.active_) {
-		GUIRect r=getSelectionRect();
-		from=r.Left() ;
-		to=r.Right() ;
-	}
-	player->OnSongStartButton(from,to,false,false) ;
-} ;
+    Player *player = Player::GetInstance();
+    unsigned char from = viewData_->songX_;
+    unsigned char to = from;
+    if (clipboard_.active_) {
+        GUIRect r = getSelectionRect();
+        from = r.Left();
+        to = r.Right();
+    }
+    player->OnSongStartButton(from, to, false, false);
+};
 
 void SongView::startCurrentRow() {
-	Player *player=Player::GetInstance() ;
-   player->SetSequencerMode(SM_LIVE) ;
-	player->OnSongStartButton(0,7,false,false) ;
+    Player *player = Player::GetInstance();
+    player->SetSequencerMode(SM_LIVE);
+    player->OnSongStartButton(0, 7, false, false);
 }
 
 void SongView::startImmediate() {
-	Player *player=Player::GetInstance() ;
+    Player *player = Player::GetInstance();
 
-	unsigned char from=viewData_->songX_ ;
-	unsigned char to=from ;	
-	player->OnSongStartButton(from,to,false,true) ;
+    unsigned char from = viewData_->songX_;
+    unsigned char to = from;
+    player->OnSongStartButton(from, to, false, true);
 }
 
 void SongView::onStop() {
-	Player *player=Player::GetInstance() ;
-	unsigned char from=viewData_->songX_ ;
-	unsigned char to=from ;
-	if (clipboard_.active_) {
-		GUIRect r=getSelectionRect();
-		from=r.Left() ;
-		to=r.Right() ;
-	}
-	player->OnSongStartButton(from,to,true,false) ;
-} ;
+    Player *player = Player::GetInstance();
+    unsigned char from = viewData_->songX_;
+    unsigned char to = from;
+    if (clipboard_.active_) {
+        GUIRect r = getSelectionRect();
+        from = r.Left();
+        to = r.Right();
+    }
+    player->OnSongStartButton(from, to, true, false);
+};
 
 void SongView::jumpToNextSection(int direction) {
 
-	int current=viewData_->songY_+viewData_->songOffset_ ;
-	bool foundGap=false ;
-	for (int i=0;i<SONG_ROW_COUNT;i++) {
-		unsigned char *start=viewData_->song_->data_+viewData_->songX_+SONG_CHANNEL_COUNT*current ;
-		if (foundGap&&(*start!=0xFF)) {
-			break ;
-		} else {
-			if (*start==0xFF) {
-				foundGap=true ;
-			}
-		}
-		current+=direction ;
-		if (current<0) {
-			current+=SONG_ROW_COUNT ;
-		}
-		if (current>=SONG_ROW_COUNT) {
-			current-=SONG_ROW_COUNT ;
-		}
-	}
-	// If we go backwards, we stil have to go to the beginning of the block
+    int current = viewData_->songY_ + viewData_->songOffset_;
+    bool foundGap = false;
+    for (int i = 0; i < SONG_ROW_COUNT; i++) {
+        unsigned char *start = viewData_->song_->data_ + viewData_->songX_ +
+                               SONG_CHANNEL_COUNT * current;
+        if (foundGap && (*start != 0xFF)) {
+            break;
+        } else {
+            if (*start == 0xFF) {
+                foundGap = true;
+            }
+        }
+        current += direction;
+        if (current < 0) {
+            current += SONG_ROW_COUNT;
+        }
+        if (current >= SONG_ROW_COUNT) {
+            current -= SONG_ROW_COUNT;
+        }
+    }
+    // If we go backwards, we stil have to go to the beginning of the block
 
-	if (direction<0) {
-		while (current>0) {
-			unsigned char *start=viewData_->song_->data_+viewData_->songX_+SONG_CHANNEL_COUNT*current ;
-			if (*start==0xFF) {
-				current++ ;
-				break ;
-			} ;
-		    current--;
-		} ;
-	}
+    if (direction < 0) {
+        while (current > 0) {
+            unsigned char *start = viewData_->song_->data_ + viewData_->songX_ +
+                                   SONG_CHANNEL_COUNT * current;
+            if (*start == 0xFF) {
+                current++;
+                break;
+            };
+            current--;
+        };
+    }
 
-	// Update viewdata position from current
+    // Update viewdata position from current
 
-	if ((current-viewData_->songOffset_>0x17)||(current-viewData_->songOffset_<0)) {
-		viewData_->songOffset_=current-4 ;
-		if (viewData_->songOffset_<0) {
-			viewData_->songOffset_=0 ;
-		}
-	}
-	viewData_->songY_=current-viewData_->songOffset_ ;
-	isDirty_=true ;
+    if ((current - viewData_->songOffset_ > 0x17) ||
+        (current - viewData_->songOffset_ < 0)) {
+        viewData_->songOffset_ = current - 4;
+        if (viewData_->songOffset_ < 0) {
+            viewData_->songOffset_ = 0;
+        }
+    }
+    viewData_->songY_ = current - viewData_->songOffset_;
+    isDirty_ = true;
 }
 
 /******************************************************
@@ -559,72 +568,71 @@ void SongView::jumpToNextSection(int direction) {
         process button mask even coming from the main
         application window
  ******************************************************/
- 
-void SongView::ProcessButtonMask(unsigned short mask,bool pressed) {
 
-	if (!pressed) {
-		if (viewMode_==VM_MUTEON) {
-			if (mask&EPBM_R) {
-				toggleMute() ;
-			}
-		} ;
-		if (viewMode_==VM_SOLOON) {
-			if (mask&EPBM_R) {
-				switchSoloMode() ;
-			}
-		} ;
-		return ;
-	} ;
-	
- 	if (viewMode_==VM_NEW) {
-		if (mask==EPBM_A) {
-			unsigned short next=viewData_->song_->chain_->GetNext() ;
-			if (next!=NO_MORE_CHAIN) {
-				setChain((unsigned char)next) ;
-				isDirty_=true ;
-			}
-			mask&=(0xFFFF-EPBM_A) ;
-		}
-	}
-	
-	if (viewMode_==VM_CLONE) {
-        if ((mask&EPBM_A)&&(mask&EPBM_L)) {
-            clonePosition() ;
-            mask&=(0xFFFF-(EPBM_A|EPBM_L));
+void SongView::ProcessButtonMask(unsigned short mask, bool pressed) {
+
+    if (!pressed) {
+        if (viewMode_ == VM_MUTEON) {
+            if (mask & EPBM_R) {
+                toggleMute();
+            }
+        };
+        if (viewMode_ == VM_SOLOON) {
+            if (mask & EPBM_R) {
+                switchSoloMode();
+            }
+        };
+        return;
+    };
+
+    if (viewMode_ == VM_NEW) {
+        if (mask == EPBM_A) {
+            unsigned short next = viewData_->song_->chain_->GetNext();
+            if (next != NO_MORE_CHAIN) {
+                setChain((unsigned char)next);
+                isDirty_ = true;
+            }
+            mask &= (0xFFFF - EPBM_A);
+        }
+    }
+
+    if (viewMode_ == VM_CLONE) {
+        if ((mask & EPBM_A) && (mask & EPBM_L)) {
+            clonePosition();
+            mask &= (0xFFFF - (EPBM_A | EPBM_L));
             canDeepClone_ = true;
+        } else {
+            viewMode_ = VM_SELECTION;
         }
-        else {
-            viewMode_=VM_SELECTION ;
-        }
-    } ;
+    };
 
-	if (canDeepClone_&&(mask&EPBM_A)&&(mask&EPBM_L)) {
-		deepClonePosition();
-		mask&=(0xFFFF-(EPBM_A|EPBM_L));
-		canDeepClone_ = false;
-	}
-	if (clipboard_.active_) {
-		viewMode_=VM_SELECTION ;
-	} ;
-	// Process selection related keys
-	
-	if (viewMode_==VM_SELECTION) {
-        if (clipboard_.active_==false) {
-            clipboard_.active_=true ;
-            clipboard_.x_=viewData_->songX_ ;
-            clipboard_.y_=viewData_->songY_ ;
-            clipboard_.offset_=viewData_->songOffset_ ;
-			saveX_=clipboard_.x_ ;
-			saveY_=clipboard_.y_ ;
-			saveOffset_=clipboard_.offset_ ;
+    if (canDeepClone_ && (mask & EPBM_A) && (mask & EPBM_L)) {
+        deepClonePosition();
+        mask &= (0xFFFF - (EPBM_A | EPBM_L));
+        canDeepClone_ = false;
+    }
+    if (clipboard_.active_) {
+        viewMode_ = VM_SELECTION;
+    };
+    // Process selection related keys
+
+    if (viewMode_ == VM_SELECTION) {
+        if (clipboard_.active_ == false) {
+            clipboard_.active_ = true;
+            clipboard_.x_ = viewData_->songX_;
+            clipboard_.y_ = viewData_->songY_;
+            clipboard_.offset_ = viewData_->songOffset_;
+            saveX_ = clipboard_.x_;
+            saveY_ = clipboard_.y_;
+            saveOffset_ = clipboard_.offset_;
         }
-        processSelectionButtonMask(mask) ;
+        processSelectionButtonMask(mask);
     } else {
-	   
+
         // Switch back to normal mode
 
-        viewMode_=VM_NORMAL ;
-        processNormalButtonMask(mask) ;
+        viewMode_ = VM_NORMAL;
+        processNormalButtonMask(mask);
     }
 }
 
@@ -633,219 +641,241 @@ void SongView::ProcessButtonMask(unsigned short mask,bool pressed) {
         process button mask in the case there is no
         selection active
  ******************************************************/
- 
+
 void SongView::processNormalButtonMask(unsigned int mask) {
 
-	// B Modifier
+    // B Modifier
 
-	if (mask&EPBM_B) {
+    if (mask & EPBM_B) {
 
-		if (mask&EPBM_DOWN) updateSongOffset(SongView::jumpLength_) ;
-		if (mask&EPBM_UP) updateSongOffset(-SongView::jumpLength_);
-		if (mask&(EPBM_RIGHT|EPBM_LEFT)) {
-		   Player *player=Player::GetInstance() ;
-           switch(player->GetSequencerMode()) {
-              case SM_SONG:
-				   player->SetSequencerMode(SM_LIVE) ;
-                   break ;
-              case SM_LIVE:
-				   player->SetSequencerMode(SM_SONG) ;
-                   break ;
-           }
-		   isDirty_=true ;
+        if (mask & EPBM_DOWN)
+            updateSongOffset(SongView::jumpLength_);
+        if (mask & EPBM_UP)
+            updateSongOffset(-SongView::jumpLength_);
+        if (mask & (EPBM_RIGHT | EPBM_LEFT)) {
+            Player *player = Player::GetInstance();
+            switch (player->GetSequencerMode()) {
+            case SM_SONG:
+                player->SetSequencerMode(SM_LIVE);
+                break;
+            case SM_LIVE:
+                player->SetSequencerMode(SM_SONG);
+                break;
+            }
+            isDirty_ = true;
         }
-		if ((mask&EPBM_A)&&(!(mask&EPBM_R))) cutPosition();
-        if (mask&EPBM_L) {
+        if ((mask & EPBM_A) && (!(mask & EPBM_R)))
+            cutPosition();
+        if (mask & EPBM_L) {
 
-            viewMode_=VM_CLONE ;
-        } ;
-		if (mask&EPBM_R) {
-			toggleMute() ;
-		} ;
-		if (mask&EPBM_START) {
-		    startImmediate() ;
+            viewMode_ = VM_CLONE;
+        };
+        if (mask & EPBM_R) {
+            toggleMute();
+        };
+        if (mask & EPBM_START) {
+            startImmediate();
         }
-	} else {
+    } else {
 
-	  // A modifier
+        // A modifier
 
-	  if (mask&EPBM_A) {
+        if (mask & EPBM_A) {
 
-		if (mask&EPBM_DOWN) updateChain(-0x10) ;
-		if (mask&EPBM_UP) updateChain(0x10) ;
-		if (mask&EPBM_LEFT) updateChain(-0x01) ;
-		if (mask&EPBM_RIGHT) updateChain(0x01) ;
-		if (mask&EPBM_L && !canDeepClone_) {
-			pasteClipboard() ;
-		}
-		if (mask==EPBM_A) {
+            if (mask & EPBM_DOWN)
+                updateChain(-0x10);
+            if (mask & EPBM_UP)
+                updateChain(0x10);
+            if (mask & EPBM_LEFT)
+                updateChain(-0x01);
+            if (mask & EPBM_RIGHT)
+                updateChain(0x01);
+            if (mask & EPBM_L && !canDeepClone_) {
+                pasteClipboard();
+            }
+            if (mask == EPBM_A) {
 
-            pasteLast() ;
-			viewMode_=VM_NEW ;
-		}
-		if (mask&EPBM_R) {
-			switchSoloMode() ;
-		} ;
-	  } else {
+                pasteLast();
+                viewMode_ = VM_NEW;
+            }
+            if (mask & EPBM_R) {
+                switchSoloMode();
+            };
+        } else {
 
-		  // R Modifier
+            // R Modifier
 
-          	if (mask&EPBM_R) {
+            if (mask & EPBM_R) {
 
-				if (mask&EPBM_L) {
-					unMuteAll() ;
-				}
-					
-				if (mask&EPBM_RIGHT) {
-					unsigned char *data=viewData_->GetCurrentSongPointer() ;
-					if (*data!=0xFF) {
-						ViewType vt=VT_CHAIN;
-						ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-						viewData_->currentChain_=*data ;
-						SetChanged();
-						NotifyObservers(&ve) ;
-					}
-				}
-				
-				if (mask&EPBM_UP) {
-					ViewType vt=VT_PROJECT;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-
-				if (mask&EPBM_DOWN) {
-					ViewType vt=VT_MIXER;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-
-				if (mask&EPBM_START) {
-				    onStop() ;
+                if (mask & EPBM_L) {
+                    unMuteAll();
                 }
-                
-	    	} else {
 
-			// L Modifier
-			
-				if (mask&EPBM_L) {
-					if (mask&EPBM_DOWN) jumpToNextSection(1) ;
-					if (mask&EPBM_UP) jumpToNextSection(-1) ;
-					if (mask&EPBM_START) startCurrentRow() ;
-					if (mask&EPBM_LEFT) nudgeTempo(-1);
-					if (mask&EPBM_RIGHT) nudgeTempo(1);
-				} else {
+                if (mask & EPBM_RIGHT) {
+                    unsigned char *data = viewData_->GetCurrentSongPointer();
+                    if (*data != 0xFF) {
+                        ViewType vt = VT_CHAIN;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        viewData_->currentChain_ = *data;
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
 
-	    			// No modifier
+                if (mask & EPBM_UP) {
+                    ViewType vt = VT_PROJECT;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
 
-	    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-	    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-	    	   		if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-	    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
+                if (mask & EPBM_DOWN) {
+                    ViewType vt = VT_MIXER;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
 
-	          		if (mask&EPBM_START) {
-					   // Always play with zero offset in chains when in songview
-					   viewData_->chainRow_ = 0;
-					   onStart() ;
-	    			}
-				}
-		    }
-	  } 
-	}
-	
-	if ((!(mask&EPBM_A))&&updatingChain_) {
-		unsigned char *c=viewData_->song_->data_+updateX_+8*(viewData_->songOffset_+updateY_) ;
-		viewData_->song_->chain_->SetUsed(*c) ;
-		updatingChain_=false ;
-	}
-} ;
+                if (mask & EPBM_START) {
+                    onStop();
+                }
+
+            } else {
+
+                // L Modifier
+
+                if (mask & EPBM_L) {
+                    if (mask & EPBM_DOWN)
+                        jumpToNextSection(1);
+                    if (mask & EPBM_UP)
+                        jumpToNextSection(-1);
+                    if (mask & EPBM_START)
+                        startCurrentRow();
+                    if (mask & EPBM_LEFT)
+                        nudgeTempo(-1);
+                    if (mask & EPBM_RIGHT)
+                        nudgeTempo(1);
+                } else {
+
+                    // No modifier
+
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+
+                    if (mask & EPBM_START) {
+                        // Always play with zero offset in chains when in
+                        // songview
+                        viewData_->chainRow_ = 0;
+                        onStart();
+                    }
+                }
+            }
+        }
+    }
+
+    if ((!(mask & EPBM_A)) && updatingChain_) {
+        unsigned char *c = viewData_->song_->data_ + updateX_ +
+                           8 * (viewData_->songOffset_ + updateY_);
+        viewData_->song_->chain_->SetUsed(*c);
+        updatingChain_ = false;
+    }
+};
 
 /******************************************************
  processSelectionButtonMask:
         process button mask in the case there is a
         selection active
  ******************************************************/
- 
+
 void SongView::processSelectionButtonMask(unsigned int mask) {
 
-	// B Modifier
+    // B Modifier
 
-	if (mask&EPBM_B) {
-		if (mask&EPBM_R) {
-			toggleMute() ;
-		} ;
-		if (mask&EPBM_L) {
-			extendSelection() ;
-		} ;
-		if (mask==EPBM_B) {
-	        copySelection() ;
-		}
+    if (mask & EPBM_B) {
+        if (mask & EPBM_R) {
+            toggleMute();
+        };
+        if (mask & EPBM_L) {
+            extendSelection();
+        };
+        if (mask == EPBM_B) {
+            copySelection();
+        }
 
     } else {
 
-	  // A modifier
+        // A modifier
 
-	  if (mask&EPBM_A) {
-            if (mask&EPBM_L) {
-                cutSelection() ;
+        if (mask & EPBM_A) {
+            if (mask & EPBM_L) {
+                cutSelection();
             }
-			if (mask&EPBM_R) {
-				switchSoloMode() ;
-			} ;
-	  } else {
+            if (mask & EPBM_R) {
+                switchSoloMode();
+            };
+        } else {
 
-		  // R Modifier
+            // R Modifier
 
-          	if (mask&EPBM_R) {
-                
-				if (mask&EPBM_L) {
-					unMuteAll() ;
-				}
-				
-				if (mask&EPBM_RIGHT) {
-					unsigned char *data=viewData_->GetCurrentSongPointer() ;
-					if (*data!=0xFF) {
-						ViewType vt=VT_CHAIN;
-						ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-						viewData_->currentChain_=*data ;
-						SetChanged();
-						NotifyObservers(&ve) ;
-					}
-				}
-				
-				if (mask&EPBM_UP) {
-					ViewType vt=VT_PROJECT;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
+            if (mask & EPBM_R) {
 
-				if (mask&EPBM_DOWN) {
-					ViewType vt=VT_MIXER;
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-
-				if (mask&EPBM_START) {
-				    onStop() ;
+                if (mask & EPBM_L) {
+                    unMuteAll();
                 }
-                
-	    	} else {
 
-    			// No modifier
-
-    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-    	   		if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-				if (mask&EPBM_START) {
-				    onStart() ;
+                if (mask & EPBM_RIGHT) {
+                    unsigned char *data = viewData_->GetCurrentSongPointer();
+                    if (*data != 0xFF) {
+                        ViewType vt = VT_CHAIN;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        viewData_->currentChain_ = *data;
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
                 }
-		    }
-	  } 
-	}
+
+                if (mask & EPBM_UP) {
+                    ViewType vt = VT_PROJECT;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+
+                if (mask & EPBM_DOWN) {
+                    ViewType vt = VT_MIXER;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+
+                if (mask & EPBM_START) {
+                    onStop();
+                }
+
+            } else {
+
+                // No modifier
+
+                if (mask & EPBM_DOWN)
+                    updateCursor(0, 1);
+                if (mask & EPBM_UP)
+                    updateCursor(0, -1);
+                if (mask & EPBM_LEFT)
+                    updateCursor(-1, 0);
+                if (mask & EPBM_RIGHT)
+                    updateCursor(1, 0);
+                if (mask & EPBM_START) {
+                    onStart();
+                }
+            }
+        }
+    }
 }
 
 /******************************************************
@@ -855,133 +885,131 @@ void SongView::processSelectionButtonMask(unsigned int mask) {
 
 void SongView::DrawView() {
 
-	Clear() ;
-	View::EnableNotification();
+    Clear();
+    View::EnableNotification();
 
-	GUITextProperties props ;
-	GUIPoint pos=GetTitlePosition() ;
+    GUITextProperties props;
+    GUIPoint pos = GetTitlePosition();
 
-// Prepare selection related information
+    // Prepare selection related information
 
-	GUIRect selRect ; 
-	if (clipboard_.active_) {
-	    selRect=GUIRect(clipboard_.x_,clipboard_.y_+clipboard_.offset_,
-                    viewData_->songX_,viewData_->songY_+viewData_->songOffset_) ;
-                    
-	    selRect.Normalize() ;
-	}
+    GUIRect selRect;
+    if (clipboard_.active_) {
+        selRect = GUIRect(clipboard_.x_, clipboard_.y_ + clipboard_.offset_,
+                          viewData_->songX_,
+                          viewData_->songY_ + viewData_->songOffset_);
 
-// Draw title
+        selRect.Normalize();
+    }
 
-	SetColor(CD_NORMAL) ;
+    // Draw title
 
-	Player *player=Player::GetInstance() ;
-	
-	std::ostringstream os;
+    SetColor(CD_NORMAL);
 
-	os << ((player->GetSequencerMode()==SM_SONG)?"Song":"Live") ;
-	os << " - " ;
-	os << songname_ ;
-	std::string buffer(os.str());
+    Player *player = Player::GetInstance();
 
-	DrawString(pos._x,pos._y,buffer.c_str(),props) ;
+    std::ostringstream os;
 
-	// Compute song grid location
+    os << ((player->GetSequencerMode() == SM_SONG) ? "Song" : "Live");
+    os << " - ";
+    os << songname_;
+    std::string buffer(os.str());
 
-	GUIPoint anchor=GetAnchor() ;
-	
-// Display row numbers
+    DrawString(pos._x, pos._y, buffer.c_str(), props);
 
-	char row[3] ;
-	pos=anchor ;
-	pos._x-=3;
-	for (int j=0;j<View::songRowCount_;j++) {
-		char p=j+viewData_->songOffset_ ;
-		((p/altRowNumber_)%2)?SetColor(CD_ROW):SetColor(CD_ROW2);
-		hex2char(p,row) ;
-		DrawString(pos._x,pos._y,row,props) ;
-		pos._y+=1 ;
-	}
+    // Compute song grid location
 
+    GUIPoint anchor = GetAnchor();
 
-	SetColor(CD_NORMAL) ;
+    // Display row numbers
 
-	pos=anchor ;
-	unsigned char *data=viewData_->song_->data_+(SONG_CHANNEL_COUNT*viewData_->songOffset_) ;
-	short dx=3 ;
-	short dy=1 ;
-	for (int j=0;j<View::songRowCount_;j++) {
+    char row[3];
+    pos = anchor;
+    pos._x -= 3;
+    for (int j = 0; j < View::songRowCount_; j++) {
+        char p = j + viewData_->songOffset_;
+        ((p / altRowNumber_) % 2) ? SetColor(CD_ROW) : SetColor(CD_ROW2);
+        hex2char(p, row);
+        DrawString(pos._x, pos._y, row, props);
+        pos._y += 1;
+    }
 
-		pos._x=anchor._x ;
+    SetColor(CD_NORMAL);
 
-		for (int i=0; i<8;i++) {
-            
-            bool invert=false ;
-            
+    pos = anchor;
+    unsigned char *data =
+        viewData_->song_->data_ + (SONG_CHANNEL_COUNT * viewData_->songOffset_);
+    short dx = 3;
+    short dy = 1;
+    for (int j = 0; j < View::songRowCount_; j++) {
+
+        pos._x = anchor._x;
+
+        for (int i = 0; i < 8; i++) {
+
+            bool invert = false;
+
             // see if we need to invert current step
             // if there's a selection or we are at cursor position
-            
+
             if (clipboard_.active_) {
-                if ((i>=selRect.Left())&&(i<=selRect.Right())&&
-                    (j+viewData_->songOffset_>=selRect.Top())&&
-                    (j+viewData_->songOffset_<=selRect.Bottom())) {
-                        invert=true ;
+                if ((i >= selRect.Left()) && (i <= selRect.Right()) &&
+                    (j + viewData_->songOffset_ >= selRect.Top()) &&
+                    (j + viewData_->songOffset_ <= selRect.Bottom())) {
+                    invert = true;
                 }
             } else {
-			    if (i==viewData_->songX_&&j==viewData_->songY_) {
-                    invert=true ;
+                if (i == viewData_->songX_ && j == viewData_->songY_) {
+                    invert = true;
                 }
             }
-			
-			// draw current step
-			
-			unsigned char d=*data++ ;
 
-			if (d==0xFE) {
-				SetColor(CD_SONGVIEWFE) ;
-			} 
-			else if (d==0x00) {
-				SetColor(CD_SONGVIEW00) ;
-			} 
-			else{
-				SetColor(CD_NORMAL) ;
-			}
-           
+            // draw current step
+
+            unsigned char d = *data++;
+
+            if (d == 0xFE) {
+                SetColor(CD_SONGVIEWFE);
+            } else if (d == 0x00) {
+                SetColor(CD_SONGVIEW00);
+            } else {
+                SetColor(CD_NORMAL);
+            }
+
             if (invert) {
-				SetColor(CD_HILITE2) ;
-				props.invert_=true ;
-			}
+                SetColor(CD_HILITE2);
+                props.invert_ = true;
+            }
 
-			if (d==0xFF) {
-				DrawString(pos._x,pos._y,"--",props) ;
-			} 
-			else {
-				hex2char(d,row) ;
-				DrawString(pos._x,pos._y,row,props) ;
-			}
-			
-			// Put back drawing state
-			
-			if (invert) {
-				SetColor(CD_NORMAL) ;
-				props.invert_=false ;
-			}
-			
-		    // Next step
-		    
-			pos._x+=dx;
-		}
-		pos._y+=dy ;
-	}
-	SetColor(CD_NORMAL) ;
+            if (d == 0xFF) {
+                DrawString(pos._x, pos._y, "--", props);
+            } else {
+                hex2char(d, row);
+                DrawString(pos._x, pos._y, row, props);
+            }
 
-    drawMap() ;
-	drawNotes() ;
-    
-	if (player->IsRunning()) {
-		OnPlayerUpdate(PET_UPDATE) ;
-	} ;
-} ;
+            // Put back drawing state
+
+            if (invert) {
+                SetColor(CD_NORMAL);
+                props.invert_ = false;
+            }
+
+            // Next step
+
+            pos._x += dx;
+        }
+        pos._y += dy;
+    }
+    SetColor(CD_NORMAL);
+
+    drawMap();
+    drawNotes();
+
+    if (player->IsRunning()) {
+        OnPlayerUpdate(PET_UPDATE);
+    };
+};
 
 /******************************************************
  OnPlayterUpdate:
@@ -989,146 +1017,146 @@ void SongView::DrawView() {
         provide visual feedback of currently played
         position
  ******************************************************/
- 
-void SongView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
 
-	SyncMaster *sync=SyncMaster::GetInstance() ;
-	if ((eventType==PET_UPDATE)&&(!sync->MajorSlice())) return ;
+void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
-	Player *player=Player::GetInstance() ;
+    SyncMaster *sync = SyncMaster::GetInstance();
+    if ((eventType == PET_UPDATE) && (!sync->MajorSlice()))
+        return;
 
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint pos=anchor ;
-	pos._x-=1 ;
+    Player *player = Player::GetInstance();
 
-	GUITextProperties props ;
-	SetColor(CD_CURSOR) ;
+    GUIPoint anchor = GetAnchor();
+    GUIPoint pos = anchor;
+    pos._x -= 1;
 
-	// Loop on all channels
+    GUITextProperties props;
+    SetColor(CD_CURSOR);
 
-	for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
+    // Loop on all channels
 
-    // Clear all current positions
+    for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
 
-		int y=lastPlayedPosition_[i]-viewData_->songOffset_ ;
-		if (y>=0 && y<View::songRowCount_ &&
-			viewData_->playMode_ != PM_AUDITION) {
-			pos._y=anchor._y+y ;
-			DrawString(pos._x,pos._y," ",props) ;
-		}
+        // Clear all current positions
 
-		// Clear all last queued positions
+        int y = lastPlayedPosition_[i] - viewData_->songOffset_;
+        if (y >= 0 && y < View::songRowCount_ &&
+            viewData_->playMode_ != PM_AUDITION) {
+            pos._y = anchor._y + y;
+            DrawString(pos._x, pos._y, " ", props);
+        }
 
-		y=lastQueuedPosition_[i]-viewData_->songOffset_ ;
-		if (y>=0 && y<View::songRowCount_) {
-			pos._y=anchor._y+y ;
-			DrawString(pos._x,pos._y," ",props) ;
-		}
+        // Clear all last queued positions
 
-		// For each playing position, draw current location
+        y = lastQueuedPosition_[i] - viewData_->songOffset_;
+        if (y >= 0 && y < View::songRowCount_) {
+            pos._y = anchor._y + y;
+            DrawString(pos._x, pos._y, " ", props);
+        }
 
-		if (player->IsChannelPlaying(i)) {
-			if (eventType!=PET_STOP) {
-				if (viewData_->currentPlayChain_[i]!=0xFF) {
-					int y=viewData_->songPlayPos_[i]-viewData_->songOffset_ ;
-					if (y>=0 && y<View::songRowCount_) {
-						pos._y=anchor._y+y ;
-						if (!player->IsChannelMuted(i)) {
+        // For each playing position, draw current location
+
+        if (player->IsChannelPlaying(i)) {
+            if (eventType != PET_STOP) {
+                if (viewData_->currentPlayChain_[i] != 0xFF) {
+                    int y = viewData_->songPlayPos_[i] - viewData_->songOffset_;
+                    if (y >= 0 && y < View::songRowCount_) {
+                        pos._y = anchor._y + y;
+                        if (!player->IsChannelMuted(i)) {
                             SetColor(CD_PLAY);
-							DrawString(pos._x,pos._y,">",props);
-						} else {
+                            DrawString(pos._x, pos._y, ">", props);
+                        } else {
                             SetColor(CD_MUTE);
-							DrawString(pos._x,pos._y,"-",props);
-						}
+                            DrawString(pos._x, pos._y, "-", props);
+                        }
                         SetColor(CD_CURSOR);
-						lastPlayedPosition_[i]=viewData_->songPlayPos_[i];
-					}
-				}
-			}
-		}
-		
-		// If in live mode, update queued position
+                        lastPlayedPosition_[i] = viewData_->songPlayPos_[i];
+                    }
+                }
+            }
+        }
 
-		if (player->GetSequencerMode()==SM_LIVE) {
-			if (player->GetQueueingMode(i)!=QM_NONE) {
+        // If in live mode, update queued position
 
-				if (eventType!=PET_STOP) {
-					int y=player->GetQueuePosition(i)-viewData_->songOffset_ ;
-					if (y>=0 && y<View::songRowCount_) {
-						pos._y=anchor._y+y ;
-						char *indicator=player->GetLiveIndicator(i) ;
-						DrawString(pos._x,pos._y,indicator,props) ;
-						lastQueuedPosition_[i]=player->GetQueuePosition(i) ;
-					}
-				}
-			} ;
-		}
-		pos._x+=3 ;
-	}
+        if (player->GetSequencerMode() == SM_LIVE) {
+            if (player->GetQueueingMode(i) != QM_NONE) {
 
-	SetColor(CD_NORMAL) ;
-
-	// Draw clipping indicator & CPU usage
-
-  if (View::miniLayout_) {
-      pos._y=0 ;
-      pos._x=25 ;
-  } else {
-      pos=anchor ;
-      pos._x+=25 ;
-  }
-    
-	if (player->Clipped()) {
-           DrawString(pos._x,pos._y,"clip",props); 
-  } else {
-           DrawString(pos._x,pos._y,"----",props); 
+                if (eventType != PET_STOP) {
+                    int y =
+                        player->GetQueuePosition(i) - viewData_->songOffset_;
+                    if (y >= 0 && y < View::songRowCount_) {
+                        pos._y = anchor._y + y;
+                        char *indicator = player->GetLiveIndicator(i);
+                        DrawString(pos._x, pos._y, indicator, props);
+                        lastQueuedPosition_[i] = player->GetQueuePosition(i);
+                    }
+                }
+            };
+        }
+        pos._x += 3;
     }
 
-	char strbuffer[10] ;
-	pos._y+=1 ;
-	sprintf(strbuffer,"%3.3d%%",player->GetPlayedBufferPercentage()) ; 
-	DrawString(pos._x,pos._y,strbuffer,props) ;
+    SetColor(CD_NORMAL);
 
-    System *sys=System::GetInstance() ;
-    int batt=sys->GetBatteryLevel() ;
-    if (batt>=0) {
-		if (batt<90) {
-			SetColor(CD_HILITE2) ;
-			invertBatt_=!invertBatt_ ;
-		} else {
-			invertBatt_=false ;
-		} ;
-		props.invert_=invertBatt_ ;
+    // Draw clipping indicator & CPU usage
 
-	    pos._y+=1 ;
-    	sprintf(strbuffer,"%3.3d",batt) ; 
-	    DrawString(pos._x,pos._y,strbuffer,props) ;
+    if (View::miniLayout_) {
+        pos._y = 0;
+        pos._x = 25;
+    } else {
+        pos = anchor;
+        pos._x += 25;
     }
 
-	if (eventType!=PET_STOP) {
-		SetColor(CD_NORMAL) ;
-		props.invert_=false ;
-		int time=int(player->GetPlayTime()) ;
-		int mi=time/60 ;
-		int se=time-mi*60 ;
-		sprintf(strbuffer,"%2.2d:%2.2d",mi,se) ; 
-		pos._y+=1 ;	
-		DrawString(pos._x,pos._y,strbuffer,props) ;
-	}
-	drawNotes() ;
-} ;
+    if (player->Clipped()) {
+        DrawString(pos._x, pos._y, "clip", props);
+    } else {
+        DrawString(pos._x, pos._y, "----", props);
+    }
 
+    char strbuffer[10];
+    pos._y += 1;
+    sprintf(strbuffer, "%3.3d%%", player->GetPlayedBufferPercentage());
+    DrawString(pos._x, pos._y, strbuffer, props);
+
+    System *sys = System::GetInstance();
+    int batt = sys->GetBatteryLevel();
+    if (batt >= 0) {
+        if (batt < 90) {
+            SetColor(CD_HILITE2);
+            invertBatt_ = !invertBatt_;
+        } else {
+            invertBatt_ = false;
+        };
+        props.invert_ = invertBatt_;
+
+        pos._y += 1;
+        sprintf(strbuffer, "%3.3d", batt);
+        DrawString(pos._x, pos._y, strbuffer, props);
+    }
+
+    if (eventType != PET_STOP) {
+        SetColor(CD_NORMAL);
+        props.invert_ = false;
+        int time = int(player->GetPlayTime());
+        int mi = time / 60;
+        int se = time - mi * 60;
+        sprintf(strbuffer, "%2.2d:%2.2d", mi, se);
+        pos._y += 1;
+        DrawString(pos._x, pos._y, strbuffer, props);
+    }
+    drawNotes();
+};
 
 void SongView::nudgeTempo(int direction) {
-	ApplicationCommandDispatcher *dispatcher=ApplicationCommandDispatcher::GetInstance();
-	switch(direction) {
-		case -1:
-			dispatcher->OnNudgeDown();
-			break;
-		case 1:
-			dispatcher->OnNudgeUp();
-			break;
-	}
+    ApplicationCommandDispatcher *dispatcher =
+        ApplicationCommandDispatcher::GetInstance();
+    switch (direction) {
+    case -1:
+        dispatcher->OnNudgeDown();
+        break;
+    case 1:
+        dispatcher->OnNudgeUp();
+        break;
+    }
 }
-
-

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1034,11 +1034,14 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
 					if (y>=0 && y<View::songRowCount_) {
 						pos._y=anchor._y+y ;
 						if (!player->IsChannelMuted(i)) {
-							DrawString(pos._x,pos._y,">",props) ;
+                            SetColor(CD_PLAY);
+							DrawString(pos._x,pos._y,">",props);
 						} else {
-							DrawString(pos._x,pos._y,"-",props) ;
+                            SetColor(CD_MUTE);
+							DrawString(pos._x,pos._y,"-",props);
 						}
-						lastPlayedPosition_[i]=viewData_->songPlayPos_[i] ;
+                        SetColor(CD_CURSOR);
+						lastPlayedPosition_[i]=viewData_->songPlayPos_[i];
 					}
 				}
 			}

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -4,85 +4,84 @@
 
 #include "BaseClasses/View.h"
 
-class SongView ;
+class SongView;
 
-class SongView: public View {
-public:
-	SongView(GUIWindow &w,ViewData *viewData,const char *song) ;
-    ~SongView() ;
-    
-	// View implementation
-	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
-	virtual void DrawView() ;
-	virtual void OnPlayerUpdate(PlayerEventType ,unsigned int tick=0)  ;
-	virtual void OnFocus() ;
+class SongView : public View {
+  public:
+    SongView(GUIWindow &w, ViewData *viewData, const char *song);
+    ~SongView();
 
-protected:
-    void processNormalButtonMask(unsigned int mask) ;
-    void processSelectionButtonMask(unsigned int mask) ;
-        
-	void extendSelection() ;
-	void updateChain(int offset) ;
-	void updateSongOffset(int offset) ;
-	void updateCursor(int dx,int dy) ;
-	void setChain(unsigned char) ;
-	void cutPosition() ;
-	void clonePosition() ;
-	void deepClonePosition() ;
-	void pasteLast() ;
-	void fillClipboardData() ;
-	GUIRect getSelectionRect() ;
+    // View implementation
+    virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+    virtual void DrawView();
+    virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
+    virtual void OnFocus();
+
+  protected:
+    void processNormalButtonMask(unsigned int mask);
+    void processSelectionButtonMask(unsigned int mask);
+
+    void extendSelection();
+    void updateChain(int offset);
+    void updateSongOffset(int offset);
+    void updateCursor(int dx, int dy);
+    void setChain(unsigned char);
+    void cutPosition();
+    void clonePosition();
+    void deepClonePosition();
+    void pasteLast();
+    void fillClipboardData();
+    GUIRect getSelectionRect();
     void copySelection();
-    void pasteClipboard() ;	
-    void cutSelection() ;
+    void pasteClipboard();
+    void cutSelection();
 
-	void unMuteAll() ;
-	void toggleMute() ;
-	void switchSoloMode() ;
-	
-	void onStart() ;
-	void startCurrentRow() ;
-	void startImmediate() ;
-	void onStop() ;
+    void unMuteAll();
+    void toggleMute();
+    void switchSoloMode();
 
-	void jumpToNextSection(int dir) ;
+    void onStart();
+    void startCurrentRow();
+    void startImmediate();
+    void onStop();
 
-private:
+    void jumpToNextSection(int dir);
 
-	bool updatingChain_ ;        // .Flag that tells we're updating chain
-                                   //  so we don't allocate chains while
-                                   //  doing multiple A+ARROWS
+  private:
+    bool updatingChain_; // .Flag that tells we're updating chain
+                         //  so we don't allocate chains while
+                         //  doing multiple A+ARROWS
 
-	int updateX_ ;               // . Position where update is happening
-	int updateY_ ;               //
+    int updateX_; // . Position where update is happening
+    int updateY_; //
 
-	unsigned char lastChain_ ;    // .Last chain clipboard
+    unsigned char lastChain_; // .Last chain clipboard
 
-	int lastPlayedPosition_[8] ;  // .Last position played for song
-								  //  used for drawing purpose
-	
-	int lastQueuedPosition_[8] ;  // .Last live queued position for song
-								  //  used for drawing purpose
+    int lastPlayedPosition_[8]; // .Last position played for song
+                                //  used for drawing purpose
 
-	struct {                      // .Clipboard structure
-        bool active_ ;            // .If currently making a selection
-        unsigned char *data_ ;    // .Null if clipboard empty
-        int x_ ;                  // .Current selection positions
-        int y_ ;                  // .
-        int offset_ ;             // .
-        int width_ ;              // .Size of selection
-        int height_ ;             // .
-    } clipboard_ ;
+    int lastQueuedPosition_[8]; // .Last live queued position for song
+                                //  used for drawing purpose
 
-	int saveX_ ;
-	int saveY_ ;
-	int saveOffset_ ;
-	std::string songname_ ;
-	bool invertBatt_ ;
-	bool needClear_ ;
-	bool canDeepClone_;
-	void nudgeTempo(int direction);
-	uint8_t jumpLength_;		  // When jumping columns with B
-} ;
+    struct {                  // .Clipboard structure
+        bool active_;         // .If currently making a selection
+        unsigned char *data_; // .Null if clipboard empty
+        int x_;               // .Current selection positions
+        int y_;               // .
+        int offset_;          // .
+        int width_;           // .Size of selection
+        int height_;          // .
+    } clipboard_;
+
+    int saveX_;
+    int saveY_;
+    int saveOffset_;
+    std::string songname_;
+    bool invertBatt_;
+    bool needClear_;
+    bool canDeepClone_;
+    void nudgeTempo(int direction);
+    uint8_t jumpLength_; // When jumping columns with B
+};
 
 #endif

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -871,7 +871,7 @@ void TableView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
 
 		pos._x=anchor._x-1 ;
 		pos._y=anchor._y+lastPosition_[0] ;
-		SetColor(CD_CURSOR) ;
+		SetColor(CD_PLAY) ;
 		DrawString(pos._x,pos._y,">",props) ;
 
 		pos._x+=10 ;

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -1,193 +1,191 @@
 #include "TableView.h"
-#include "Application/Utils/char.h"
 #include "Application/Instruments/CommandList.h"
 #include "Application/Player/TablePlayback.h"
 #include "Application/Utils/HelpLegend.h"
+#include "Application/Utils/char.h"
 
-#define FCC_EDIT MAKE_FOURCC('T','B','E','D')
+#define FCC_EDIT MAKE_FOURCC('T', 'B', 'E', 'D')
 
-TableView::TableView(GUIWindow &w,ViewData *viewData):
-   View(w,viewData),
-   cmdEdit_("edit",FCC_EDIT,0)
-{
-	row_=0 ;
-	col_=0 ;
-	GUIPoint pos(0,10) ;
-	cmdEditField_=new UIBigHexVarField(pos,cmdEdit_,4,"%4.4X",0,0xFFFF,16,true) ;
+TableView::TableView(GUIWindow &w, ViewData *viewData)
+    : View(w, viewData), cmdEdit_("edit", FCC_EDIT, 0) {
+    row_ = 0;
+    col_ = 0;
+    GUIPoint pos(0, 10);
+    cmdEditField_ =
+        new UIBigHexVarField(pos, cmdEdit_, 4, "%4.4X", 0, 0xFFFF, 16, true);
 
-	lastVol_=0 ;
-	lastTick_=0 ;
-	lastTsp_=0 ;
-	lastCmd_=I_CMD_NONE ;
-	lastParam_=0 ;
+    lastVol_ = 0;
+    lastTick_ = 0;
+    lastTsp_ = 0;
+    lastCmd_ = I_CMD_NONE;
+    lastParam_ = 0;
 
-	clipboard_.active_=false ;
-	clipboard_.width_=0 ;
-	clipboard_.height_=0 ;
-
+    clipboard_.active_ = false;
+    clipboard_.width_ = 0;
+    clipboard_.height_ = 0;
 }
 
-
-TableView::~TableView() {
-}
+TableView::~TableView() {}
 
 void TableView::OnFocus() {
-	clipboard_.active_=false ;
-	viewMode_=VM_NORMAL ;
-	lastPosition_[0]=lastPosition_[1]=lastPosition_[2]=0 ;
-	updateCursor(0,0) ;
-}; 
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    lastPosition_[0] = lastPosition_[1] = lastPosition_[2] = 0;
+    updateCursor(0, 0);
+};
 
 void TableView::cutPosition() {
 
-    clipboard_.active_=true ;
-    clipboard_.row_=row_ ;
-    clipboard_.col_=col_ ;
-    saveRow_=row_ ;
-	saveCol_=col_ ;
+    clipboard_.active_ = true;
+    clipboard_.row_ = row_;
+    clipboard_.col_ = col_;
+    saveRow_ = row_;
+    saveCol_ = col_;
 
-	if ((col_==0)||(col_==2)||(col_==4)) col_+=1 ; // This way, A+B on note cuts
-						   // the instruments too and parameters get cut with commands
-    cutSelection() ;
-} ;
+    if ((col_ == 0) || (col_ == 2) || (col_ == 4))
+        col_ += 1; // This way, A+B on note cuts
+                   // the instruments too and parameters get cut with commands
+    cutSelection();
+};
 
 GUIRect TableView::getSelectionRect() {
-    GUIRect r(clipboard_.col_,clipboard_.row_,col_,row_) ;
-    r.Normalize() ;
-    return r ;
-} ;
+    GUIRect r(clipboard_.col_, clipboard_.row_, col_, row_);
+    r.Normalize();
+    return r;
+};
 
 void TableView::fillClipboardData() {
 
-  // Get Current normalized selection rect
-  
-    GUIRect selRect=getSelectionRect() ;
+    // Get Current normalized selection rect
 
-  // Get size & store in clipboard
-  
-    clipboard_.width_=selRect.Width()+1 ;
-    clipboard_.height_=selRect.Height()+1 ;
-    clipboard_.row_=selRect.Top() ;
-    clipboard_.col_=selRect.Left() ;
-      
-  // Copy the data
-    
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    GUIRect selRect = getSelectionRect();
 
-    uint *src1=table.cmd1_ ;
-    uint *dst1=clipboard_.cmd1_ ;
-    ushort *src2=table.param1_ ;
-    ushort *dst2=clipboard_.param1_ ;
-    uint *src3=table.cmd2_ ;
-    uint *dst3=clipboard_.cmd2_ ;
-    ushort *src4=table.param2_ ;
-    ushort *dst4=clipboard_.param2_ ;
-    uint *src5=table.cmd3_ ;
-    uint *dst5=clipboard_.cmd3_ ;
-    ushort *src6=table.param3_ ;
-    ushort *dst6=clipboard_.param3_ ;
-    
-    for (int i=0;i<clipboard_.height_;i++) {
-        dst1[i]=src1[clipboard_.row_+i] ;
-        dst2[i]=src2[clipboard_.row_+i] ;
-        dst3[i]=src3[clipboard_.row_+i] ;
-        dst4[i]=src4[clipboard_.row_+i] ;
-        dst5[i]=src5[clipboard_.row_+i] ;
-        dst6[i]=src6[clipboard_.row_+i] ;
-    } ;
-	updateCursor(0,0) ;
-} ;
+    // Get size & store in clipboard
+
+    clipboard_.width_ = selRect.Width() + 1;
+    clipboard_.height_ = selRect.Height() + 1;
+    clipboard_.row_ = selRect.Top();
+    clipboard_.col_ = selRect.Left();
+
+    // Copy the data
+
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
+
+    uint *src1 = table.cmd1_;
+    uint *dst1 = clipboard_.cmd1_;
+    ushort *src2 = table.param1_;
+    ushort *dst2 = clipboard_.param1_;
+    uint *src3 = table.cmd2_;
+    uint *dst3 = clipboard_.cmd2_;
+    ushort *src4 = table.param2_;
+    ushort *dst4 = clipboard_.param2_;
+    uint *src5 = table.cmd3_;
+    uint *dst5 = clipboard_.cmd3_;
+    ushort *src6 = table.param3_;
+    ushort *dst6 = clipboard_.param3_;
+
+    for (int i = 0; i < clipboard_.height_; i++) {
+        dst1[i] = src1[clipboard_.row_ + i];
+        dst2[i] = src2[clipboard_.row_ + i];
+        dst3[i] = src3[clipboard_.row_ + i];
+        dst4[i] = src4[clipboard_.row_ + i];
+        dst5[i] = src5[clipboard_.row_ + i];
+        dst6[i] = src6[clipboard_.row_ + i];
+    };
+    updateCursor(0, 0);
+};
 
 void TableView::extendSelection() {
-	GUIRect rect=getSelectionRect() ;
-	if (rect.Left()>0||rect.Right()<6) {
-		if (col_<clipboard_.col_) {
-			col_=0 ;
-			clipboard_.col_=6 ;
-		} else {
-			col_=6 ;
-			clipboard_.col_=0 ;
-		}
-		isDirty_=true ;
-	} else {
-		if (row_<clipboard_.row_) {
-			row_=0 ;
-			clipboard_.row_=15 ;
-		} else {
-			clipboard_.row_=0 ;
-			row_=15 ;
-		}
-		isDirty_=true ;
-	}
+    GUIRect rect = getSelectionRect();
+    if (rect.Left() > 0 || rect.Right() < 6) {
+        if (col_ < clipboard_.col_) {
+            col_ = 0;
+            clipboard_.col_ = 6;
+        } else {
+            col_ = 6;
+            clipboard_.col_ = 0;
+        }
+        isDirty_ = true;
+    } else {
+        if (row_ < clipboard_.row_) {
+            row_ = 0;
+            clipboard_.row_ = 15;
+        } else {
+            clipboard_.row_ = 0;
+            row_ = 15;
+        }
+        isDirty_ = true;
+    }
 }
 
 void TableView::copySelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
- 
-    
-    fillClipboardData() ;
-    
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    row_=saveRow_ ;
-    col_=saveCol_ ;
-    
-    isDirty_=true ; 
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
+
+    fillClipboardData();
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    row_ = saveRow_;
+    col_ = saveCol_;
+
+    isDirty_ = true;
 };
 
 void TableView::cutSelection() {
 
- // Keep up with row,col of selection coz
- // fillClipboardData will trash it
-     
-    fillClipboardData() ;
+    // Keep up with row,col of selection coz
+    // fillClipboardData will trash it
 
-// Loop over selection col, row & clear data inside it
+    fillClipboardData();
 
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
-    uint *dst1=table.cmd1_ ;
-    ushort *dst2=table.param1_ ;
-    uint *dst3=table.cmd2_ ;
-    ushort *dst4=table.param2_ ;
-    uint *dst5=table.cmd3_ ;
-    ushort *dst6=table.param3_ ;
+    // Loop over selection col, row & clear data inside it
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<clipboard_.height_;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                    dst1[j+clipboard_.row_]=I_CMD_NONE ;
-                    break ;
-                case 1:
-                    dst2[j+clipboard_.row_]=0x0000 ;
-                    break ;
-                case 2:
-                    dst3[j+clipboard_.row_]=I_CMD_NONE ;
-                    break ;
-                case 3:
-                    dst4[j+clipboard_.row_]=0x0000 ;
-                    break ;
-                case 4:
-                    dst5[j+clipboard_.row_]=I_CMD_NONE ;
-                    break ;
-                case 5:
-                    dst6[j+clipboard_.row_]=0x0000 ;
-                    break ;
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
+    uint *dst1 = table.cmd1_;
+    ushort *dst2 = table.param1_;
+    uint *dst3 = table.cmd2_;
+    ushort *dst4 = table.param2_;
+    uint *dst5 = table.cmd3_;
+    ushort *dst6 = table.param3_;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < clipboard_.height_; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+                dst1[j + clipboard_.row_] = I_CMD_NONE;
+                break;
+            case 1:
+                dst2[j + clipboard_.row_] = 0x0000;
+                break;
+            case 2:
+                dst3[j + clipboard_.row_] = I_CMD_NONE;
+                break;
+            case 3:
+                dst4[j + clipboard_.row_] = 0x0000;
+                break;
+            case 4:
+                dst5[j + clipboard_.row_] = I_CMD_NONE;
+                break;
+            case 5:
+                dst6[j + clipboard_.row_] = 0x0000;
+                break;
             }
         }
     }
-    
-// Clear selection, end selection process & reposition cursor
 
-    clipboard_.active_=false ;
-    viewMode_=VM_NORMAL ;
-    row_=saveRow_ ;
-    col_=saveCol_ ;
-	updateCursor(0,0) ;
-    isDirty_=true ; 
-} ;
+    // Clear selection, end selection process & reposition cursor
+
+    clipboard_.active_ = false;
+    viewMode_ = VM_NORMAL;
+    row_ = saveRow_;
+    col_ = saveCol_;
+    updateCursor(0, 0);
+    isDirty_ = true;
+};
 
 /******************************************************
  pasteClipboard:
@@ -196,699 +194,727 @@ void TableView::cutSelection() {
 
 void TableView::pasteClipboard() {
 
- // Get number of row to paste
- 
-    int height=clipboard_.height_ ;
-/*    if (row_+height>16) {
-        height=16-row_ ;
-    }
-  */  
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    // Get number of row to paste
 
-    uint *dst1=table.cmd1_ ;
-    uint *src1=clipboard_.cmd1_ ;
-    ushort *dst2=table.param1_ ;
-    ushort *src2=clipboard_.param1_ ;
-    uint *dst3=table.cmd2_ ;
-    uint *src3=clipboard_.cmd2_ ;
-    ushort *dst4=table.param2_ ;
-    ushort *src4=clipboard_.param2_ ;
-    uint *dst5=table.cmd3_ ;
-    uint *src5=clipboard_.cmd3_ ;
-    ushort *dst6=table.param3_ ;
-    ushort *src6=clipboard_.param3_ ;
+    int height = clipboard_.height_;
+    /*    if (row_+height>16) {
+            height=16-row_ ;
+        }
+      */
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
 
-	uint* noCmd = (uint*) -1;
-	ushort* noPrm = (ushort*) -1;
-	uint* srcCmd[5] = {src1, noCmd, src3, noCmd, src5};
-	ushort* srcPrm[6] = {noPrm, src2, noPrm, src4, noPrm, src6};
-	uint* dstCmd[5] = {dst1, noCmd, dst3, noCmd, dst5};
-	ushort* dstPrm[6] = {noPrm, dst2, noPrm, dst4, noPrm, dst6};
+    uint *dst1 = table.cmd1_;
+    uint *src1 = clipboard_.cmd1_;
+    ushort *dst2 = table.param1_;
+    ushort *src2 = clipboard_.param1_;
+    uint *dst3 = table.cmd2_;
+    uint *src3 = clipboard_.cmd2_;
+    ushort *dst4 = table.param2_;
+    ushort *src4 = clipboard_.param2_;
+    uint *dst5 = table.cmd3_;
+    uint *src5 = clipboard_.cmd3_;
+    ushort *dst6 = table.param3_;
+    ushort *src6 = clipboard_.param3_;
 
-	bool wasUpdated = false;
+    uint *noCmd = (uint *)-1;
+    ushort *noPrm = (ushort *)-1;
+    uint *srcCmd[5] = {src1, noCmd, src3, noCmd, src5};
+    ushort *srcPrm[6] = {noPrm, src2, noPrm, src4, noPrm, src6};
+    uint *dstCmd[5] = {dst1, noCmd, dst3, noCmd, dst5};
+    ushort *dstPrm[6] = {noPrm, dst2, noPrm, dst4, noPrm, dst6};
 
-    for (int i=0;i<clipboard_.width_;i++) {
-        for (int j=0;j<height;j++) {
-            switch(i+clipboard_.col_) {
-                case 0:
-                case 2:
-                case 4:
-					if ((col_ + i) == 0 || (col_ + i) == 2 || (col_ + i) == 4) { // Don't allow commands in params, etc
-						dstCmd[col_ + i][(row_ + j)%16] = srcCmd[clipboard_.col_ + i][j];
-						wasUpdated = true;
-					}
-                    break;
-                case 1:
-                case 3:
-                case 5:
-					if ((col_ + i) == 1 || (col_ + i) == 3 || (col_ + i) == 5) {
-						dstPrm[col_ + i][(row_ + j)%16] = srcPrm[clipboard_.col_ + i][j];
-						wasUpdated = true;
-					}
-                    break;
+    bool wasUpdated = false;
+
+    for (int i = 0; i < clipboard_.width_; i++) {
+        for (int j = 0; j < height; j++) {
+            switch (i + clipboard_.col_) {
+            case 0:
+            case 2:
+            case 4:
+                if ((col_ + i) == 0 || (col_ + i) == 2 ||
+                    (col_ + i) == 4) { // Don't allow commands in params, etc
+                    dstCmd[col_ + i][(row_ + j) % 16] =
+                        srcCmd[clipboard_.col_ + i][j];
+                    wasUpdated = true;
+                }
+                break;
+            case 1:
+            case 3:
+            case 5:
+                if ((col_ + i) == 1 || (col_ + i) == 3 || (col_ + i) == 5) {
+                    dstPrm[col_ + i][(row_ + j) % 16] =
+                        srcPrm[clipboard_.col_ + i][j];
+                    wasUpdated = true;
+                }
+                break;
             }
         }
     }
-	if (wasUpdated)	{
-		updateCursor(0x00, ((row_ + height)%16 - row_));
-		isDirty_ = true;
-	}
-} ;
+    if (wasUpdated) {
+        updateCursor(0x00, ((row_ + height) % 16 - row_));
+        isDirty_ = true;
+    }
+};
 
+void TableView::updateCursor(int dx, int dy) {
+    col_ += dx;
+    row_ += dy;
+    if (col_ > 5)
+        col_ = 5;
+    if (col_ < 0)
+        col_ = 0;
+    if (row_ > 15)
+        row_ = 15;
+    if (row_ < 0)
+        row_ = 0;
 
-void TableView::updateCursor(int dx,int dy) {
-	col_+=dx ;
-	row_+=dy ;
-	if (col_>5) col_=5 ;
-	if (col_<0) col_=0 ;
-	if (row_>15) row_=15 ;
-	if (row_<0) row_=0 ;
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
 
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    GUIPoint anchor = GetAnchor();
+    GUIPoint p(anchor);
+    switch (col_) {
+    case 1:
+        p._x += 5;
+        p._y += row_;
+        cmdEditField_->SetPosition(p);
+        cmdEdit_.SetInt(*(table.param1_ + row_));
+        break;
+    case 3:
+        p._x += 15;
+        p._y += row_;
+        cmdEditField_->SetPosition(p);
+        cmdEdit_.SetInt(*(table.param2_ + row_));
+        break;
+    case 5:
+        p._x += 25;
+        p._y += row_;
+        cmdEditField_->SetPosition(p);
+        cmdEdit_.SetInt(*(table.param3_ + row_));
+        break;
+    };
 
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint p(anchor) ;
-	switch(col_) {
-		case 1:
-			p._x+=5 ;
-			p._y+=row_ ;
-			cmdEditField_->SetPosition(p) ;
-			cmdEdit_.SetInt(*(table.param1_+row_)) ;
-			break ;
-		case 3:
-			p._x+=15 ;
-			p._y+=row_ ;
-			cmdEditField_->SetPosition(p) ;
-			cmdEdit_.SetInt(*(table.param2_+row_)) ;
-			break ;
-		case 5:
-			p._x+=25 ;
-			p._y+=row_ ;
-			cmdEditField_->SetPosition(p) ;
-			cmdEdit_.SetInt(*(table.param3_+row_)) ;
-			break ;
-	} ;
-
-
-	isDirty_=true;
-} ;
+    isDirty_ = true;
+};
 
 void TableView::warpToNeighbour(int dir) {
 
-	int current=viewData_->currentTable_+dir;
+    int current = viewData_->currentTable_ + dir;
 
-	if (current>=TABLE_COUNT) {
-		current-=TABLE_COUNT ;
-	}
-	if (current<0) {
-		current+=TABLE_COUNT ;
-	}
-	viewData_->currentTable_=current ;
-	updateCursor(0,0) ;
-	isDirty_=true ;
+    if (current >= TABLE_COUNT) {
+        current -= TABLE_COUNT;
+    }
+    if (current < 0) {
+        current += TABLE_COUNT;
+    }
+    viewData_->currentTable_ = current;
+    updateCursor(0, 0);
+    isDirty_ = true;
 }
 
 void TableView::updateCursorValue(int offset) {
 
-	unsigned char *c=0 ;
-	unsigned char limit=0 ;
-	bool wrap=false ;
-    FourCC *cc ;
-    
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    unsigned char *c = 0;
+    unsigned char limit = 0;
+    bool wrap = false;
+    FourCC *cc;
 
-    
-	switch (col_) {
-		case 0:
-			cc=table.cmd1_+row_ ;
-			switch (offset) {
-				case 0x01 :
-					*cc=CommandList::GetNext(*cc) ;
-					break ;
-				case 0x10:
-					*cc=CommandList::GetNextAlpha(*cc) ;
-					break ;
-				case -0x01 :
-					*cc=CommandList::GetPrev(*cc) ;
-					break ;
-				case -0x10:
-					*cc=CommandList::GetPrevAlpha(*cc) ;
-					break ;
-			}
-			lastCmd_=*cc ;
-			break ;
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
 
-		case 1:
-			switch(offset) {
-				case 0x01:
-					cmdEditField_->ProcessArrow(EPBM_RIGHT) ;
-					break ;
-				case 0x10:
-					cmdEditField_->ProcessArrow(EPBM_UP) ;
-					break ;
-				case -0x01:
-					cmdEditField_->ProcessArrow(EPBM_LEFT) ;
-					break ;
-				case -0x10:
-					cmdEditField_->ProcessArrow(EPBM_DOWN) ;
-					break ;
-			}
-			*(table.param1_+row_)=cmdEdit_.GetInt() ;
-			lastParam_=cmdEdit_.GetInt() ;
-			break;
+    switch (col_) {
+    case 0:
+        cc = table.cmd1_ + row_;
+        switch (offset) {
+        case 0x01:
+            *cc = CommandList::GetNext(*cc);
+            break;
+        case 0x10:
+            *cc = CommandList::GetNextAlpha(*cc);
+            break;
+        case -0x01:
+            *cc = CommandList::GetPrev(*cc);
+            break;
+        case -0x10:
+            *cc = CommandList::GetPrevAlpha(*cc);
+            break;
+        }
+        lastCmd_ = *cc;
+        break;
 
-		case 2:
-			cc=table.cmd2_+row_ ;
-			switch (offset) {
-				case 0x01 :
-					*cc=CommandList::GetNext(*cc) ;
-					break ;
-				case 0x10:
-					*cc=CommandList::GetNextAlpha(*cc) ;
-					break ;
-				case -0x01 :
-					*cc=CommandList::GetPrev(*cc) ;
-					break ;
-				case -0x10:
-					*cc=CommandList::GetPrevAlpha(*cc) ;
-					break ;
-			}
-			lastCmd_=*cc ;
-			break ;
-		case 3:
-			switch(offset) {
-				case 0x01:
-					cmdEditField_->ProcessArrow(EPBM_RIGHT) ;
-					break ;
-				case 0x10:
-					cmdEditField_->ProcessArrow(EPBM_UP) ;
-					break ;
-				case -0x01:
-					cmdEditField_->ProcessArrow(EPBM_LEFT) ;
-					break ;
-				case -0x10:
-					cmdEditField_->ProcessArrow(EPBM_DOWN) ;
-					break ;
-			}
-			*(table.param2_+row_)=cmdEdit_.GetInt() ;
-			lastParam_=cmdEdit_.GetInt() ;
-			break;
-		case 4:
-			cc=table.cmd3_+row_ ;
-			switch (offset) {
-				case 0x01 :
-					*cc=CommandList::GetNext(*cc) ;
-					break ;
-				case 0x10:
-					*cc=CommandList::GetNextAlpha(*cc) ;
-					break ;
-				case -0x01 :
-					*cc=CommandList::GetPrev(*cc) ;
-					break ;
-				case -0x10:
-					*cc=CommandList::GetPrevAlpha(*cc) ;
-					break ;
-			}
-			lastCmd_=*cc ;
-			break ;
-		case 5:
-			switch(offset) {
-				case 0x01:
-					cmdEditField_->ProcessArrow(EPBM_RIGHT) ;
-					break ;
-				case 0x10:
-					cmdEditField_->ProcessArrow(EPBM_UP) ;
-					break ;
-				case -0x01:
-					cmdEditField_->ProcessArrow(EPBM_LEFT) ;
-					break ;
-				case -0x10:
-					cmdEditField_->ProcessArrow(EPBM_DOWN) ;
-					break ;
-			}
-			*(table.param3_+row_)=cmdEdit_.GetInt() ;
-			lastParam_=cmdEdit_.GetInt() ;
-			break;
+    case 1:
+        switch (offset) {
+        case 0x01:
+            cmdEditField_->ProcessArrow(EPBM_RIGHT);
+            break;
+        case 0x10:
+            cmdEditField_->ProcessArrow(EPBM_UP);
+            break;
+        case -0x01:
+            cmdEditField_->ProcessArrow(EPBM_LEFT);
+            break;
+        case -0x10:
+            cmdEditField_->ProcessArrow(EPBM_DOWN);
+            break;
+        }
+        *(table.param1_ + row_) = cmdEdit_.GetInt();
+        lastParam_ = cmdEdit_.GetInt();
+        break;
 
-	}
-	if (c) {
-		updateData(c,offset,limit,wrap) ;
-		switch(col_) {
-			case 0:
-				lastVol_=*c ;
-				break ;
-			case 1:
-				lastTick_=*c ;
-				break ;
-			case 2:
-				lastTsp_=*c ;
-				break ;
-		}
-	}
-	isDirty_=true ;
+    case 2:
+        cc = table.cmd2_ + row_;
+        switch (offset) {
+        case 0x01:
+            *cc = CommandList::GetNext(*cc);
+            break;
+        case 0x10:
+            *cc = CommandList::GetNextAlpha(*cc);
+            break;
+        case -0x01:
+            *cc = CommandList::GetPrev(*cc);
+            break;
+        case -0x10:
+            *cc = CommandList::GetPrevAlpha(*cc);
+            break;
+        }
+        lastCmd_ = *cc;
+        break;
+    case 3:
+        switch (offset) {
+        case 0x01:
+            cmdEditField_->ProcessArrow(EPBM_RIGHT);
+            break;
+        case 0x10:
+            cmdEditField_->ProcessArrow(EPBM_UP);
+            break;
+        case -0x01:
+            cmdEditField_->ProcessArrow(EPBM_LEFT);
+            break;
+        case -0x10:
+            cmdEditField_->ProcessArrow(EPBM_DOWN);
+            break;
+        }
+        *(table.param2_ + row_) = cmdEdit_.GetInt();
+        lastParam_ = cmdEdit_.GetInt();
+        break;
+    case 4:
+        cc = table.cmd3_ + row_;
+        switch (offset) {
+        case 0x01:
+            *cc = CommandList::GetNext(*cc);
+            break;
+        case 0x10:
+            *cc = CommandList::GetNextAlpha(*cc);
+            break;
+        case -0x01:
+            *cc = CommandList::GetPrev(*cc);
+            break;
+        case -0x10:
+            *cc = CommandList::GetPrevAlpha(*cc);
+            break;
+        }
+        lastCmd_ = *cc;
+        break;
+    case 5:
+        switch (offset) {
+        case 0x01:
+            cmdEditField_->ProcessArrow(EPBM_RIGHT);
+            break;
+        case 0x10:
+            cmdEditField_->ProcessArrow(EPBM_UP);
+            break;
+        case -0x01:
+            cmdEditField_->ProcessArrow(EPBM_LEFT);
+            break;
+        case -0x10:
+            cmdEditField_->ProcessArrow(EPBM_DOWN);
+            break;
+        }
+        *(table.param3_ + row_) = cmdEdit_.GetInt();
+        lastParam_ = cmdEdit_.GetInt();
+        break;
+    }
+    if (c) {
+        updateData(c, offset, limit, wrap);
+        switch (col_) {
+        case 0:
+            lastVol_ = *c;
+            break;
+        case 1:
+            lastTick_ = *c;
+            break;
+        case 2:
+            lastTsp_ = *c;
+            break;
+        }
+    }
+    isDirty_ = true;
 }
 
 void TableView::pasteLast() {
-	uint   *i=0 ;
-	
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    uint *i = 0;
 
-	switch (col_) {
-		case 0:
-			i=table.cmd1_+row_ ;
-			if (*i==I_CMD_NONE) {
-				*i=lastCmd_ ;
-				isDirty_=true ;
-			} else {
-				lastCmd_=*i ;
-			}
-			break ;
-			
-		case 1:
-			break ;
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
 
-		case 2:
-			i=table.cmd2_+row_ ;
-			if (*i==I_CMD_NONE) {
-				*i=lastCmd_ ;
-				isDirty_=true ;
-			} else {
-				lastCmd_=*i ;
-			}
-			break ;
+    switch (col_) {
+    case 0:
+        i = table.cmd1_ + row_;
+        if (*i == I_CMD_NONE) {
+            *i = lastCmd_;
+            isDirty_ = true;
+        } else {
+            lastCmd_ = *i;
+        }
+        break;
 
-		case 3:
-			break ;
+    case 1:
+        break;
 
-		case 4:
-			i=table.cmd3_+row_ ;
-			if (*i==I_CMD_NONE) {
-				*i=lastCmd_ ;
-				isDirty_=true ;
-			} else {
-				lastCmd_=*i ;
-			}
-			break ;
+    case 2:
+        i = table.cmd2_ + row_;
+        if (*i == I_CMD_NONE) {
+            *i = lastCmd_;
+            isDirty_ = true;
+        } else {
+            lastCmd_ = *i;
+        }
+        break;
 
-		case 5:
-			break ;
-	} 
-} ;
+    case 3:
+        break;
 
-void TableView::ProcessButtonMask(unsigned short mask,bool pressed) {
+    case 4:
+        i = table.cmd3_ + row_;
+        if (*i == I_CMD_NONE) {
+            *i = lastCmd_;
+            isDirty_ = true;
+        } else {
+            lastCmd_ = *i;
+        }
+        break;
 
-	if (!pressed) {
-		return ;
-	}
-	if (viewMode_==VM_SELECTION) {
-		if (!clipboard_.active_) {
-			clipboard_.active_=true ;
-			clipboard_.col_=col_ ;
-			clipboard_.row_=row_ ;
-			saveCol_=col_ ;
-			saveRow_=row_ ;
-		}
-		processSelectionButtonMask(mask) ;
-	}  else {
-		processNormalButtonMask(mask) ;
-	} ;
+    case 5:
+        break;
+    }
+};
 
+void TableView::ProcessButtonMask(unsigned short mask, bool pressed) {
+
+    if (!pressed) {
+        return;
+    }
+    if (viewMode_ == VM_SELECTION) {
+        if (!clipboard_.active_) {
+            clipboard_.active_ = true;
+            clipboard_.col_ = col_;
+            clipboard_.row_ = row_;
+            saveCol_ = col_;
+            saveRow_ = row_;
+        }
+        processSelectionButtonMask(mask);
+    } else {
+        processNormalButtonMask(mask);
+    };
 }
 
 void TableView::processNormalButtonMask(unsigned short mask) {
 
-	Player *player=Player::GetInstance() ;
+    Player *player = Player::GetInstance();
 
-	if (mask&EPBM_B) {
-		if (mask&EPBM_LEFT) warpToNeighbour(-1) ;
-		if (mask&EPBM_RIGHT) warpToNeighbour(+1);
-		if (mask&EPBM_DOWN) warpToNeighbour(-16) ;
-		if (mask&EPBM_UP) warpToNeighbour(16) ;
-		if (mask&EPBM_A) cutPosition();
-		if (mask&EPBM_L) viewMode_=VM_SELECTION ;
+    if (mask & EPBM_B) {
+        if (mask & EPBM_LEFT)
+            warpToNeighbour(-1);
+        if (mask & EPBM_RIGHT)
+            warpToNeighbour(+1);
+        if (mask & EPBM_DOWN)
+            warpToNeighbour(-16);
+        if (mask & EPBM_UP)
+            warpToNeighbour(16);
+        if (mask & EPBM_A)
+            cutPosition();
+        if (mask & EPBM_L)
+            viewMode_ = VM_SELECTION;
 
-	} else {
+    } else {
 
-	  // A modifier
+        // A modifier
 
-	  if (mask&EPBM_A) {
-		if (mask&EPBM_DOWN) updateCursorValue(-0x10) ;
-		if (mask&EPBM_UP) updateCursorValue(0x10) ;
-		if (mask&EPBM_LEFT) updateCursorValue(-0x01) ;
-		if (mask&EPBM_RIGHT) updateCursorValue(0x01) ;
-		if (mask==EPBM_A) pasteLast() ;
-		if (mask&EPBM_L) pasteClipboard() ;
-	  } else {
+        if (mask & EPBM_A) {
+            if (mask & EPBM_DOWN)
+                updateCursorValue(-0x10);
+            if (mask & EPBM_UP)
+                updateCursorValue(0x10);
+            if (mask & EPBM_LEFT)
+                updateCursorValue(-0x01);
+            if (mask & EPBM_RIGHT)
+                updateCursorValue(0x01);
+            if (mask == EPBM_A)
+                pasteLast();
+            if (mask & EPBM_L)
+                pasteClipboard();
+        } else {
 
-		  // R Modifier
+            // R Modifier
 
-          	if (mask&EPBM_R) {
-				if (mask&EPBM_UP) {
-					ViewType vt=(viewType_==VT_TABLE?VT_PHRASE:VT_INSTRUMENT);
-					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-					SetChanged();
-					NotifyObservers(&ve) ;
-				}
-				if (mask&EPBM_LEFT) {
-					if (viewType_==VT_TABLE2) {
-						ViewType vt=VT_TABLE;
-						ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-						SetChanged();
-						NotifyObservers(&ve) ;
-					}
-				}
-				if (mask&EPBM_RIGHT) {
-					if (viewType_==VT_TABLE) {
-						ViewType vt=VT_TABLE2;
-						ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-						SetChanged();
-						NotifyObservers(&ve) ;
-					}
-				}
-    			if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
-    			}			
+            if (mask & EPBM_R) {
+                if (mask & EPBM_UP) {
+                    ViewType vt =
+                        (viewType_ == VT_TABLE ? VT_PHRASE : VT_INSTRUMENT);
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+                if (mask & EPBM_LEFT) {
+                    if (viewType_ == VT_TABLE2) {
+                        ViewType vt = VT_TABLE;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
+                if (mask & EPBM_RIGHT) {
+                    if (viewType_ == VT_TABLE) {
+                        ViewType vt = VT_TABLE2;
+                        ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                        SetChanged();
+                        NotifyObservers(&ve);
+                    }
+                }
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
 
-			} else {
-				// L MOdifier
-         		if (mask&EPBM_R) {
-				} else {
+            } else {
+                // L MOdifier
+                if (mask & EPBM_R) {
+                } else {
 
-				// No modifier
-                
-    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-    			if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-    			if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
-    			}
- 
-				} 
-			} 
-	  }
-	}
+                    // No modifier
+
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+                    if (mask & EPBM_START) {
+                        player->OnStartButton(PM_PHRASE, viewData_->songX_,
+                                              false, viewData_->chainRow_);
+                    }
+                }
+            }
+        }
+    }
 }
 
 void TableView::processSelectionButtonMask(unsigned short mask) {
 
-	Player *player=Player::GetInstance() ;
+    Player *player = Player::GetInstance();
 
-	if (mask&EPBM_B) {
-        if (mask&EPBM_L) {
-          extendSelection() ;
+    if (mask & EPBM_B) {
+        if (mask & EPBM_L) {
+            extendSelection();
         } else {
-		  copySelection() ;
-       }
-	} else {
-        
-      // A Modifer
-      
-	  if (mask&EPBM_A) {
-		if (mask&EPBM_L) cutSelection() ;
-//		if (mask&EPBM_R) switchSoloMode() ;
-	  } else {
-            
-        // R Modifier
-        
-        if (mask&EPBM_R) {
-			if (mask&EPBM_UP) {
-				ViewType vt=VT_PHRASE;
-				ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
-				SetChanged();
-				NotifyObservers(&ve) ;
-			}
-    		if (mask&EPBM_START) {
-				player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
-    		}
-/*			if (mask&EPBM_L) unMuteAll() ;
-*/
-		} else {
-            // L Modifier
-            if (mask&EPBM_L) {
-
-            } else {
-                // No modifier
-                
-    			if (mask&EPBM_DOWN) updateCursor(0,1) ;
-    			if (mask&EPBM_UP) updateCursor(0,-1) ;
-    			if (mask&EPBM_LEFT) updateCursor(-1,0)  ;
-    			if (mask&EPBM_RIGHT) updateCursor(1,0) ;
-    			if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
-    			}
-            }
-		}
-	  } 
-	}	    
-}
-
-void TableView::setTextProps(GUITextProperties &props,int row,int col,bool restore) {
-
-	bool invert=false ;
-	
-	if (clipboard_.active_) {
-        GUIRect selRect=getSelectionRect() ;
-        if ((row>=selRect.Left())&&(row<=selRect.Right())&&
-            (col>=selRect.Top())&&(col<=selRect.Bottom())) {
-                invert=true ;
-        }        
+            copySelection();
+        }
     } else {
-    	if ((col_==row)&&(row_==col)) {
-            invert=true ;
+
+        // A Modifer
+
+        if (mask & EPBM_A) {
+            if (mask & EPBM_L)
+                cutSelection();
+            //		if (mask&EPBM_R) switchSoloMode() ;
+        } else {
+
+            // R Modifier
+
+            if (mask & EPBM_R) {
+                if (mask & EPBM_UP) {
+                    ViewType vt = VT_PHRASE;
+                    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+                    SetChanged();
+                    NotifyObservers(&ve);
+                }
+                if (mask & EPBM_START) {
+                    player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
+                /*			if (mask&EPBM_L) unMuteAll() ;
+                 */
+            } else {
+                // L Modifier
+                if (mask & EPBM_L) {
+
+                } else {
+                    // No modifier
+
+                    if (mask & EPBM_DOWN)
+                        updateCursor(0, 1);
+                    if (mask & EPBM_UP)
+                        updateCursor(0, -1);
+                    if (mask & EPBM_LEFT)
+                        updateCursor(-1, 0);
+                    if (mask & EPBM_RIGHT)
+                        updateCursor(1, 0);
+                    if (mask & EPBM_START) {
+                        player->OnStartButton(PM_PHRASE, viewData_->songX_,
+                                              false, viewData_->chainRow_);
+                    }
+                }
+            }
         }
     }
-    
+}
+
+void TableView::setTextProps(GUITextProperties &props, int row, int col,
+                             bool restore) {
+
+    bool invert = false;
+
+    if (clipboard_.active_) {
+        GUIRect selRect = getSelectionRect();
+        if ((row >= selRect.Left()) && (row <= selRect.Right()) &&
+            (col >= selRect.Top()) && (col <= selRect.Bottom())) {
+            invert = true;
+        }
+    } else {
+        if ((col_ == row) && (row_ == col)) {
+            invert = true;
+        }
+    }
+
     if (invert) {
         if (restore) {
-    		SetColor(CD_NORMAL) ;
-	   	    props.invert_=false;
+            SetColor(CD_NORMAL);
+            props.invert_ = false;
         } else {
-    		SetColor(CD_HILITE2) ;
-	   	    props.invert_=true;            
+            SetColor(CD_HILITE2);
+            props.invert_ = true;
         }
-	}
+    }
 }
 
 void TableView::DrawView() {
 
-	Clear() ;
+    Clear();
 
-	GUITextProperties props ;
-	GUIPoint pos=GetTitlePosition() ;
+    GUITextProperties props;
+    GUIPoint pos = GetTitlePosition();
 
-	Table &table=TableHolder::GetInstance()->GetTable(viewData_->currentTable_) ;
+    Table &table =
+        TableHolder::GetInstance()->GetTable(viewData_->currentTable_);
 
-// Draw title
+    // Draw title
 
-	char title[20] ;
-	SetColor(CD_NORMAL) ;
-	sprintf(title,"Table %2.2x",viewData_->currentTable_) ;
-	DrawString(pos._x,pos._y,title,props) ;
+    char title[20];
+    SetColor(CD_NORMAL);
+    sprintf(title, "Table %2.2x", viewData_->currentTable_);
+    DrawString(pos._x, pos._y, title, props);
 
-// Compute song grid location
+    // Compute song grid location
 
-	GUIPoint anchor=GetAnchor() ;
-	
-// Display row numbers
+    GUIPoint anchor = GetAnchor();
 
-	char buffer[6] ;
-	pos=anchor ;
-	pos._x-=3 ;
-	for (int j=0;j<16;j++) {
-		((j/altRowNumber_)%2)?SetColor(CD_ROW):SetColor(CD_ROW2);
-		hex2char(j,buffer) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-		pos._y++ ;
-	}
+    // Display row numbers
 
-	SetColor(CD_NORMAL) ;
+    char buffer[6];
+    pos = anchor;
+    pos._x -= 3;
+    for (int j = 0; j < 16; j++) {
+        ((j / altRowNumber_) % 2) ? SetColor(CD_ROW) : SetColor(CD_ROW2);
+        hex2char(j, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        pos._y++;
+    }
 
-// Draw command 1
+    SetColor(CD_NORMAL);
 
-	pos=anchor ;
+    // Draw command 1
 
-	FourCC *f=table.cmd1_ ;
+    pos = anchor;
 
-	buffer[4]=0 ;
+    FourCC *f = table.cmd1_;
 
-	for (int j=0;j<16;j++) {
-		FourCC command=*f++ ;
-		fourCC2char(command,buffer) ;
-        setTextProps(props,0,j,false) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,0,j,true) ;
-		pos._y++ ;
-		if (j==row_ && (col_ == 0 || col_ == 1)) {
-			printHelpLegend(command, props);
-		}
-	}
+    buffer[4] = 0;
 
+    for (int j = 0; j < 16; j++) {
+        FourCC command = *f++;
+        fourCC2char(command, buffer);
+        setTextProps(props, 0, j, false);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 0, j, true);
+        pos._y++;
+        if (j == row_ && (col_ == 0 || col_ == 1)) {
+            printHelpLegend(command, props);
+        }
+    }
 
-// Draw commands params 1
+    // Draw commands params 1
 
-	pos=anchor ;
-	pos._x+=5 ;
+    pos = anchor;
+    pos._x += 5;
 
-	ushort *param=table.param1_ ;
-	buffer[5]=0 ;
-	
-	for (int j=0;j<16;j++) {
-		ushort p=*param++ ;
-        setTextProps(props,1,j,false) ;
-		hexshort2char(p,buffer) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-      	setTextProps(props,1,j,true) ;
-		pos._y++ ;
-	}
-	
-// Draw commands 2
+    ushort *param = table.param1_;
+    buffer[5] = 0;
 
-	pos=anchor ;
-	pos._x+=10 ;
+    for (int j = 0; j < 16; j++) {
+        ushort p = *param++;
+        setTextProps(props, 1, j, false);
+        hexshort2char(p, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 1, j, true);
+        pos._y++;
+    }
 
-	f=table.cmd2_ ;
+    // Draw commands 2
 
-	buffer[4]=0 ;
+    pos = anchor;
+    pos._x += 10;
 
-	for (int j=0;j<16;j++) {
-		FourCC command=*f++ ;
-		fourCC2char(command,buffer) ;
-        setTextProps(props,2,j,false) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,2,j,true) ;
-		pos._y++ ;
-		if (j==row_ && (col_ == 2 || col_ == 3)) {
-			printHelpLegend(command, props);
-		}
-	}
+    f = table.cmd2_;
 
-// Draw commands params
+    buffer[4] = 0;
 
-	pos=anchor ;
-	pos._x+=15 ;
+    for (int j = 0; j < 16; j++) {
+        FourCC command = *f++;
+        fourCC2char(command, buffer);
+        setTextProps(props, 2, j, false);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 2, j, true);
+        pos._y++;
+        if (j == row_ && (col_ == 2 || col_ == 3)) {
+            printHelpLegend(command, props);
+        }
+    }
 
-	param=table.param2_ ;
-	buffer[5]=0 ;
+    // Draw commands params
 
-	for (int j=0;j<16;j++) {
-		ushort p=*param++ ;
-        setTextProps(props,3,j,false) ;
-		hexshort2char(p,buffer) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,3,j,true) ;
-		pos._y++ ;
-	}
+    pos = anchor;
+    pos._x += 15;
 
-// Draw command 3
+    param = table.param2_;
+    buffer[5] = 0;
 
-	pos=anchor ;
-	pos._x+=20 ;
+    for (int j = 0; j < 16; j++) {
+        ushort p = *param++;
+        setTextProps(props, 3, j, false);
+        hexshort2char(p, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 3, j, true);
+        pos._y++;
+    }
 
-	f=table.cmd3_ ;
+    // Draw command 3
 
-	buffer[4]=0 ;
+    pos = anchor;
+    pos._x += 20;
 
-	for (int j=0;j<16;j++) {
-		FourCC command=*f++ ;
-		fourCC2char(command,buffer) ;
-        setTextProps(props,4,j,false) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,4,j,true) ;
-		pos._y++ ;
-		if (j==row_ && (col_ == 4 || col_ == 5)) {
-			printHelpLegend(command, props);
-		}
-	}
+    f = table.cmd3_;
 
+    buffer[4] = 0;
 
-// Draw commands params 3
+    for (int j = 0; j < 16; j++) {
+        FourCC command = *f++;
+        fourCC2char(command, buffer);
+        setTextProps(props, 4, j, false);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 4, j, true);
+        pos._y++;
+        if (j == row_ && (col_ == 4 || col_ == 5)) {
+            printHelpLegend(command, props);
+        }
+    }
 
-	pos=anchor ;
-	pos._x+=25 ;
+    // Draw commands params 3
 
-	param=table.param3_ ;
-	buffer[5]=0 ;
-	
-	for (int j=0;j<16;j++) {
-		ushort p=*param++ ;
-        setTextProps(props,5,j,false) ;
-		hexshort2char(p,buffer) ;
-		DrawString(pos._x,pos._y,buffer,props) ;
-        setTextProps(props,5,j,true) ;
-		pos._y++ ;
-	}
-	
+    pos = anchor;
+    pos._x += 25;
 
-	if ((viewMode_!=VM_SELECTION)&&((col_==1)||(col_==3)||(col_==5))) {
-		cmdEditField_->SetFocus() ;
-		cmdEditField_->Draw(w_) ;
-	} ;
+    param = table.param3_;
+    buffer[5] = 0;
 
-	drawMap() ;
-	drawNotes() ;
+    for (int j = 0; j < 16; j++) {
+        ushort p = *param++;
+        setTextProps(props, 5, j, false);
+        hexshort2char(p, buffer);
+        DrawString(pos._x, pos._y, buffer, props);
+        setTextProps(props, 5, j, true);
+        pos._y++;
+    }
 
-	Player *player=Player::GetInstance() ;
+    if ((viewMode_ != VM_SELECTION) &&
+        ((col_ == 1) || (col_ == 3) || (col_ == 5))) {
+        cmdEditField_->SetFocus();
+        cmdEditField_->Draw(w_);
+    };
 
-	if (player->IsRunning()) {
-		OnPlayerUpdate(PET_UPDATE) ;
-	} ;
+    drawMap();
+    drawNotes();
 
+    Player *player = Player::GetInstance();
+
+    if (player->IsRunning()) {
+        OnPlayerUpdate(PET_UPDATE);
+    };
 }
 
-void TableView::OnPlayerUpdate(PlayerEventType eventType,unsigned int tick) {
+void TableView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
-	GUITextProperties props ;
-	GUIPoint anchor=GetAnchor() ;
-	GUIPoint pos ;
+    GUITextProperties props;
+    GUIPoint anchor = GetAnchor();
+    GUIPoint pos;
 
-	pos._x=anchor._x-1 ;
-	pos._y=anchor._y+lastPosition_[0] ;
-	DrawString(pos._x,pos._y," ",props) ;
-		
-	pos._x+=10 ;
-	pos._y=anchor._y+lastPosition_[1] ;
-	DrawString(pos._x,pos._y," ",props) ;
-		
-	pos._x+=10 ;
-	pos._y=anchor._y+lastPosition_[2] ;
-	DrawString(pos._x,pos._y," ",props) ;
+    pos._x = anchor._x - 1;
+    pos._y = anchor._y + lastPosition_[0];
+    DrawString(pos._x, pos._y, " ", props);
 
-	TableHolder *th=TableHolder::GetInstance() ;
-	// Get current channel
-	int channel=viewData_->songX_ ;
-	// Table associated to the channel playerpb
-	TablePlayback &tpb=TablePlayback::GetTablePlayback(channel) ;
-	Table *playbackTable=tpb.GetTable() ;
-	// Table we're viewing
-	Table &viewTable=th->GetTable(viewData_->currentTable_) ;
-	if (playbackTable==&viewTable && viewData_->playMode_ != PM_AUDITION) {
+    pos._x += 10;
+    pos._y = anchor._y + lastPosition_[1];
+    DrawString(pos._x, pos._y, " ", props);
 
+    pos._x += 10;
+    pos._y = anchor._y + lastPosition_[2];
+    DrawString(pos._x, pos._y, " ", props);
 
-		lastPosition_[0]=tpb.GetPlaybackPosition(0) ;
-		lastPosition_[1]=tpb.GetPlaybackPosition(1) ;
-		lastPosition_[2]=tpb.GetPlaybackPosition(2) ;
+    TableHolder *th = TableHolder::GetInstance();
+    // Get current channel
+    int channel = viewData_->songX_;
+    // Table associated to the channel playerpb
+    TablePlayback &tpb = TablePlayback::GetTablePlayback(channel);
+    Table *playbackTable = tpb.GetTable();
+    // Table we're viewing
+    Table &viewTable = th->GetTable(viewData_->currentTable_);
+    if (playbackTable == &viewTable && viewData_->playMode_ != PM_AUDITION) {
 
-		pos._x=anchor._x-1 ;
-		pos._y=anchor._y+lastPosition_[0] ;
-		SetColor(CD_PLAY) ;
-		DrawString(pos._x,pos._y,">",props) ;
+        lastPosition_[0] = tpb.GetPlaybackPosition(0);
+        lastPosition_[1] = tpb.GetPlaybackPosition(1);
+        lastPosition_[2] = tpb.GetPlaybackPosition(2);
 
-		pos._x+=10 ;
-		pos._y=anchor._y+lastPosition_[1] ;
-		DrawString(pos._x,pos._y,">",props) ;
+        pos._x = anchor._x - 1;
+        pos._y = anchor._y + lastPosition_[0];
+        SetColor(CD_PLAY);
+        DrawString(pos._x, pos._y, ">", props);
 
-		pos._x+=10 ;
-		pos._y=anchor._y+lastPosition_[2] ;
-		DrawString(pos._x,pos._y,">",props) ;
+        pos._x += 10;
+        pos._y = anchor._y + lastPosition_[1];
+        DrawString(pos._x, pos._y, ">", props);
 
-	} ;
-	drawNotes() ;
+        pos._x += 10;
+        pos._y = anchor._y + lastPosition_[2];
+        DrawString(pos._x, pos._y, ">", props);
+    };
+    drawNotes();
 }
 
 void TableView::printHelpLegend(FourCC command, GUITextProperties props) {
-	std::string* cmdStr = getHelpLegend(command);
-	DrawString(10, 0, cmdStr[0].c_str(), props);
-	DrawString(10, 1, cmdStr[1].c_str(), props);
-	DrawString(10, 2, cmdStr[2].c_str(), props);
+    std::string *cmdStr = getHelpLegend(command);
+    DrawString(10, 0, cmdStr[0].c_str(), props);
+    DrawString(10, 1, cmdStr[1].c_str(), props);
+    DrawString(10, 2, cmdStr[2].c_str(), props);
 }

--- a/sources/Application/Views/TableView.h
+++ b/sources/Application/Views/TableView.h
@@ -1,73 +1,71 @@
 #ifndef _TABLE_VIEW_H_
 #define _TABLE_VIEW_H_
 
+#include "Application/Model/Table.h"
 #include "BaseClasses/UIBigHexVarField.h"
 #include "BaseClasses/View.h"
 #include "ViewData.h"
-#include "Application/Model/Table.h"
 
-class TableView: public View {
-public:
-	TableView(GUIWindow &w,ViewData *viewData) ;
-	~TableView() ;
-	virtual void ProcessButtonMask(unsigned short mask,bool pressed) ;
-	virtual void DrawView() ;
-	virtual void OnPlayerUpdate(PlayerEventType ,unsigned int tick=0) ;
+class TableView : public View {
+  public:
+    TableView(GUIWindow &w, ViewData *viewData);
+    ~TableView();
+    virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+    virtual void DrawView();
+    virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
     virtual void OnFocus();
 
-protected:
+  protected:
+    void processNormalButtonMask(unsigned short mask);
+    void processSelectionButtonMask(unsigned short mask);
 
-	void processNormalButtonMask(unsigned short mask) ;
-	void processSelectionButtonMask(unsigned short mask) ;
+    void cutPosition();
+    void pasteLast();
+    void copySelection();
+    void cutSelection();
+    void pasteClipboard();
 
-	void cutPosition() ;
-	void pasteLast() ;
-	void copySelection() ;
-	void cutSelection() ;
-	void pasteClipboard() ;
+    void fillClipboardData();
+    void extendSelection();
 
-	void fillClipboardData() ;
-	void extendSelection() ;
+    void updateCursor(int dx, int dy);
+    void updateCursorValue(int offset);
+    void setTextProps(GUITextProperties &props, int row, int col, bool restore);
+    void warpToNeighbour(int dir);
 
-	void updateCursor(int dx,int dy) ;
-	void updateCursorValue(int offset) ;
-	void setTextProps(GUITextProperties &props,int row,int col,bool restore) ;
-	void warpToNeighbour(int dir) ;
+    GUIRect getSelectionRect();
 
-	GUIRect getSelectionRect() ;
+  private:
+    int row_;
+    int col_;
+    uchar lastVol_;
+    uchar lastTick_;
+    uchar lastTsp_;
+    int lastCmd_;
+    int lastParam_;
 
-private:
-	int row_ ;
-	int col_ ;
-	uchar lastVol_ ;
-	uchar lastTick_ ;
-	uchar lastTsp_ ;
-	int lastCmd_ ;
-	int lastParam_ ;
+    Variable cmdEdit_;
+    UIBigHexVarField *cmdEditField_;
+    void printHelpLegend(FourCC command, GUITextProperties props);
 
-	Variable cmdEdit_ ;
-	UIBigHexVarField *cmdEditField_ ;
-	void printHelpLegend(FourCC command, GUITextProperties props);
-    
-	struct clipboard {
-		bool active_ ;
-		int col_ ;
-		int row_ ;
-		int width_ ;
-		int height_ ;
-		uint cmd1_[16] ;
- 		ushort param1_[16] ;
-		uint cmd2_[16] ;
- 		ushort param2_[16] ;
-		uint cmd3_[16] ;
- 		ushort param3_[16] ;
-	} clipboard_ ;
+    struct clipboard {
+        bool active_;
+        int col_;
+        int row_;
+        int width_;
+        int height_;
+        uint cmd1_[16];
+        ushort param1_[16];
+        uint cmd2_[16];
+        ushort param2_[16];
+        uint cmd3_[16];
+        ushort param3_[16];
+    } clipboard_;
 
-	uchar saveCol_ ;
-	uchar saveRow_ ;
+    uchar saveCol_;
+    uchar saveRow_;
 
-	uchar lastPosition_[3] ;
-} ;
-
+    uchar lastPosition_[3];
+};
 
 #endif


### PR DESCRIPTION
Personally i've always wanted a different color for the > play indicator to make it easier to read, in my mind it made sense to do the - mute indicator at the same time. In the default configs these are still mapped to the same color as cursor and normal.

In adition someone on Discord was after the ability to change the dialog border so I added that while I was there.

This commit also cleans up some whitespace in the parts of the code and docs that it touched.