### PR TITLE
Per-project option for soft clipping the output

### DIFF
--- a/projects/resources/X64/mapping.xml
+++ b/projects/resources/X64/mapping.xml
@@ -21,7 +21,7 @@
 
         <MAP src="key:0:a" dst="/event/b" />
         <MAP src="key:0:s" dst="/event/a" />
-        <MAP src="key:0:space" dst="/event/space" />
+        <MAP src="key:0:space" dst="/event/start" />
 <!--
     EXAMPLE
     maps the button "8" to left shoulder

--- a/sources/Application/Audio/DummyAudioOut.cpp
+++ b/sources/Application/Audio/DummyAudioOut.cpp
@@ -53,6 +53,10 @@ void DummyAudioOut::Stop() {
 	SAFE_DELETE(thread_) ;
 } ;
 
+void DummyAudioOut::SetSoftclip(int clip) {
+  
+}
+
 void DummyAudioOut::SendPulse()
 {
   SetChanged() ;

--- a/sources/Application/Audio/DummyAudioOut.cpp
+++ b/sources/Application/Audio/DummyAudioOut.cpp
@@ -53,9 +53,7 @@ void DummyAudioOut::Stop() {
 	SAFE_DELETE(thread_) ;
 } ;
 
-void DummyAudioOut::SetSoftclip(int clip) {
-  
-}
+void DummyAudioOut::SetSoftclip(int clip) {}
 
 void DummyAudioOut::SendPulse()
 {

--- a/sources/Application/Audio/DummyAudioOut.h
+++ b/sources/Application/Audio/DummyAudioOut.h
@@ -24,26 +24,26 @@ public:
     virtual bool Init()  ;
     virtual void Close() ;
     virtual bool Start() ;
-    virtual void Stop() ;
+    virtual void Stop();
 
-	virtual void Trigger()  ;
+    virtual void Trigger();
 
-	virtual bool Clipped() { return false ; } ;
+    virtual bool Clipped() { return false; };
 
-	virtual int GetPlayedBufferPercentage() { return 0; } ;
+    virtual int GetPlayedBufferPercentage() { return 0; };
 
-	void SendPulse() ;
+    void SendPulse();
 
-	virtual std::string GetAudioAPI() ;
-	virtual std::string GetAudioDevice() ;
+    virtual std::string GetAudioAPI();
+    virtual std::string GetAudioDevice() ;
 	virtual int GetAudioBufferSize() ;
 	virtual int GetAudioRequestedBufferSize() ;
 	virtual int GetAudioPreBufferCount() ;
 	virtual double GetStreamTime() ;
-  virtual void SetSoftclip(int);
+    virtual void SetSoftclip(int);
 
-private:
-	DummyOutThread *thread_ ;
+  private:
+    DummyOutThread *thread_ ;
     fixed *primarySoundBuffer_ ;
 
 } ;

--- a/sources/Application/Audio/DummyAudioOut.h
+++ b/sources/Application/Audio/DummyAudioOut.h
@@ -25,7 +25,7 @@ public:
     virtual void Close() ;
     virtual bool Start() ;
     virtual void Stop() ;
- 
+
 	virtual void Trigger()  ;
 
 	virtual bool Clipped() { return false ; } ;
@@ -40,6 +40,7 @@ public:
 	virtual int GetAudioRequestedBufferSize() ;
 	virtual int GetAudioPreBufferCount() ;
 	virtual double GetStreamTime() ;
+  virtual void SetSoftclip(int);
 
 private:
 	DummyOutThread *thread_ ;

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -170,9 +170,7 @@ void MixerService::SetMasterVolume(int vol) {
   }
 } ;
 
-void MixerService::SetSoftclip(int clip) {
-  out_->SetSoftclip(clip);
-};
+void MixerService::SetSoftclip(int clip) { out_->SetSoftclip(clip); };
 
 int MixerService::GetPlayedBufferPercentage() {
 	return out_->GetPlayedBufferPercentage() ;

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -161,8 +161,6 @@ bool MixerService::Clipped() {
 } ;
 
 void MixerService::SetMasterVolume(int vol) {
-  Mixer *mixer=Mixer::GetInstance();
-  
   fixed masterVolume = fp_mul(i2fp(vol),fl2fp(0.01f));
   
   for (int i=0;i<SONG_CHANNEL_COUNT;i++)
@@ -170,6 +168,10 @@ void MixerService::SetMasterVolume(int vol) {
     bus_[i].SetVolume(masterVolume);
   }
 } ;
+
+void MixerService::SetSoftclip(int clip) {
+  out_->SetSoftclip(clip);
+};
 
 int MixerService::GetPlayedBufferPercentage() {
 	return out_->GetPlayedBufferPercentage() ;

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -161,11 +161,12 @@ bool MixerService::Clipped() {
 } ;
 
 void MixerService::SetMasterVolume(int vol) {
-  fixed masterVolume = fp_mul(i2fp(vol),fl2fp(0.01f));
-  
-  for (int i=0;i<SONG_CHANNEL_COUNT;i++)
-  {
-    bus_[i].SetVolume(masterVolume);
+    Mixer *mixer = Mixer::GetInstance();
+
+    fixed masterVolume = fp_mul(i2fp(vol), fl2fp(0.01f));
+
+    for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+        bus_[i].SetVolume(masterVolume);
   }
 } ;
 

--- a/sources/Application/Mixer/MixerService.h
+++ b/sources/Application/Mixer/MixerService.h
@@ -49,6 +49,7 @@ public:
 
 	bool Clipped() ;
 	void SetMasterVolume(int) ;
+  void SetSoftclip(int) ;
 	int GetPlayedBufferPercentage() ;
 	
 	virtual void Execute(FourCC id,float value) ;
@@ -57,6 +58,7 @@ public:
 
 	void Lock() ;
 	void Unlock() ;
+
 
 protected:
 	void toggleRendering(bool enable) ;

--- a/sources/Application/Mixer/MixerService.h
+++ b/sources/Application/Mixer/MixerService.h
@@ -49,8 +49,8 @@ public:
 
 	bool Clipped() ;
 	void SetMasterVolume(int) ;
-  void SetSoftclip(int) ;
-	int GetPlayedBufferPercentage() ;
+    void SetSoftclip(int);
+    int GetPlayedBufferPercentage() ;
 	
 	virtual void Execute(FourCC id,float value) ;
 
@@ -58,7 +58,6 @@ public:
 
 	void Lock() ;
 	void Unlock() ;
-
 
 protected:
 	void toggleRendering(bool enable) ;

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -12,6 +12,7 @@
 #include "Application/Instruments/SampleInstrument.h"
 
 #include <math.h>
+#include "ProjectDatas.h"
 
 Project::Project()
 :Persistent("PROJECT")
@@ -27,6 +28,9 @@ tempoNudge_(0)
 	this->Insert(wrap) ;
 	Variable *transpose=new Variable("transpose",VAR_TRANSPOSE,0) ;
 	this->Insert(transpose) ;
+	Variable *softclip=new Variable("softclip",VAR_SOFTCLIP,softclipStates,2,0) ;
+	this->Insert(softclip) ;
+
 
 // Reload the midi device list
 
@@ -67,10 +71,16 @@ int Project::GetTempo() {
 } ;
 
 int Project::GetMasterVolume() {
-	Variable *v=FindVariable(VAR_MASTERVOL) ;
-	NAssert(v) ;
-	return v->GetInt() ;
+	Variable *v=FindVariable(VAR_MASTERVOL);
+	NAssert(v);
+	return v->GetInt();
 } ;
+
+int Project::GetSoftclip() {
+	Variable *v=FindVariable(VAR_SOFTCLIP);
+	NAssert(v);
+	return v->GetInt();
+}
 
 void Project::NudgeTempo(int value) {
 	if((GetTempo() + tempoNudge_) > 0)

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -28,8 +28,9 @@ tempoNudge_(0)
 	this->Insert(wrap) ;
 	Variable *transpose=new Variable("transpose",VAR_TRANSPOSE,0) ;
 	this->Insert(transpose) ;
-	Variable *softclip=new Variable("softclip",VAR_SOFTCLIP,softclipStates,2,0) ;
-	this->Insert(softclip) ;
+    Variable *softclip =
+        new Variable("softclip", VAR_SOFTCLIP, softclipStates, 5, 0);
+    this->Insert(softclip) ;
 
 
 // Reload the midi device list

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -11,8 +11,8 @@
 #include "Application/Instruments/SamplePool.h"
 #include "Application/Instruments/SampleInstrument.h"
 
-#include <math.h>
 #include "ProjectDatas.h"
+#include <math.h>
 
 Project::Project()
 :Persistent("PROJECT")
@@ -72,14 +72,14 @@ int Project::GetTempo() {
 } ;
 
 int Project::GetMasterVolume() {
-	Variable *v=FindVariable(VAR_MASTERVOL);
-	NAssert(v);
+    Variable *v = FindVariable(VAR_MASTERVOL);
+    NAssert(v);
 	return v->GetInt();
 } ;
 
 int Project::GetSoftclip() {
-	Variable *v=FindVariable(VAR_SOFTCLIP);
-	NAssert(v);
+    Variable *v = FindVariable(VAR_SOFTCLIP);
+    NAssert(v);
 	return v->GetInt();
 }
 

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -14,6 +14,7 @@
 #define VAR_WRAP        MAKE_FOURCC('W','R','A','P')
 #define VAR_MIDIDEVICE  MAKE_FOURCC('M','I','D','I')
 #define VAR_TRANSPOSE   MAKE_FOURCC('T','R','S','P')
+#define VAR_SOFTCLIP    MAKE_FOURCC('S','F','T','C')
 
 #define PROJECT_NUMBER "1"
 #define PROJECT_RELEASE "4"
@@ -36,6 +37,7 @@ public:
 	void NudgeTempo(int value) ;
 	int GetTempo() ; // Takes nudging into account
 	int GetTranspose() ;
+	int GetSoftclip() ;
 
 	void Trigger() ;
 

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -14,7 +14,7 @@
 #define VAR_WRAP        MAKE_FOURCC('W','R','A','P')
 #define VAR_MIDIDEVICE  MAKE_FOURCC('M','I','D','I')
 #define VAR_TRANSPOSE   MAKE_FOURCC('T','R','S','P')
-#define VAR_SOFTCLIP    MAKE_FOURCC('S','F','T','C')
+#define VAR_SOFTCLIP MAKE_FOURCC('S', 'F', 'T', 'C')
 
 #define PROJECT_NUMBER "1"
 #define PROJECT_RELEASE "4"
@@ -37,11 +37,11 @@ public:
 	void NudgeTempo(int value) ;
 	int GetTempo() ; // Takes nudging into account
 	int GetTranspose() ;
-	int GetSoftclip() ;
+    int GetSoftclip();
 
-	void Trigger() ;
+    void Trigger();
 
-	// I_Observer
+    // I_Observer
     virtual void Update(Observable &o,I_ObservableData *d);
  
 	InstrumentBank* GetInstrumentBank() ;

--- a/sources/Application/Model/ProjectDatas.h
+++ b/sources/Application/Model/ProjectDatas.h
@@ -1,4 +1,1 @@
-char *softclipStates[] = {
-	"off",
-	"on "
-} ;
+char *softclipStates[] = {"off", "subtle", "medium", "heavy", "insane"};

--- a/sources/Application/Model/ProjectDatas.h
+++ b/sources/Application/Model/ProjectDatas.h
@@ -1,0 +1,4 @@
+char *softclipStates[] = {
+	"off",
+	"on "
+} ;

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -1,15 +1,14 @@
 #include "PlayerMixer.h"
+#include "Application/Mixer/MixerService.h"
+#include "Application/Model/Mixer.h"
+#include "Application/Utils/char.h"
+#include "Application/Utils/fixed.h"
+#include "Services/Midi/MidiService.h"
 #include "SyncMaster.h"
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
-#include "Application/Utils/fixed.h"
-#include "Application/Utils/char.h"
-#include "Services/Midi/MidiService.h"
-#include "Application/Mixer/MixerService.h"
-#include "Application/Utils/char.h"
-#include "Application/Model/Mixer.h"
-#include <stdlib.h>
 #include <math.h>
+#include <stdlib.h>
 
 PlayerMixer::PlayerMixer() {
 
@@ -100,11 +99,11 @@ bool PlayerMixer::Clipped() {
 void PlayerMixer::Update(Observable &o,I_ObservableData *d) {
 
   // Notifies the player so that pattern data is processed
-  SetChanged() ;
-  NotifyObservers() ;
+  SetChanged();
+  NotifyObservers();
 
   // Transfer the mixer data
-  Mixer *mixer=Mixer::GetInstance() ;
+  Mixer *mixer = Mixer::GetInstance();
 
   for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
     channel_[i]->SetMixBus(mixer->GetBus(i));
@@ -203,5 +202,4 @@ void PlayerMixer::Lock() {
 void PlayerMixer::Unlock() {
 	MixerService *ms=MixerService::GetInstance() ;
 	ms->Unlock() ;
-
-} ;
+};

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -1,5 +1,3 @@
-
-
 #include "PlayerMixer.h"
 #include "SyncMaster.h"
 #include "System/Console/Trace.h"
@@ -102,21 +100,19 @@ bool PlayerMixer::Clipped() {
 void PlayerMixer::Update(Observable &o,I_ObservableData *d) {
 
   // Notifies the player so that pattern data is processed
-
-     SetChanged() ;
-     NotifyObservers() ;
+  SetChanged() ;
+  NotifyObservers() ;
 
   // Transfer the mixer data
+  Mixer *mixer=Mixer::GetInstance() ;
 
-	Mixer *mixer=Mixer::GetInstance() ;
-
-	for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
-		channel_[i]->SetMixBus(mixer->GetBus(i)) ;
-	}
-//     out_->SetMasterVolume(project_->GetMasterVolume()) ;
-	 MixerService *ms=MixerService::GetInstance() ;
-     ms->SetMasterVolume(project_->GetMasterVolume()) ;
-     clipped_=ms->Clipped() ;
+  for (int i=0;i<SONG_CHANNEL_COUNT;i++) {
+    channel_[i]->SetMixBus(mixer->GetBus(i));
+  }
+  MixerService *ms=MixerService::GetInstance();
+  ms->SetMasterVolume(project_->GetMasterVolume());
+  ms->SetSoftclip(project_->GetSoftclip());
+  clipped_=ms->Clipped();
 } ;
 
 

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -1,6 +1,7 @@
 #include "ProjectView.h"
 #include "BaseClasses/UIIntVarField.h"
 #include "BaseClasses/UIActionField.h"
+#include "BaseClasses/UIField.h"
 #include "BaseClasses/UITempoField.h"
 #include "Application/Persistency/PersistencyService.h"
 #include "System/System/System.h"
@@ -115,6 +116,11 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 	UIIntVarField *f2=new UIIntVarField(position,*v,"transpose: %3.2d",-48,48,0x1,0xC) ;
 	T_SimpleList<UIField>::Insert(f2) ;
 
+	v=project_->FindVariable(VAR_SOFTCLIP) ;
+  position._y+=1 ;
+	UIIntVarField *f3=new UIIntVarField(position,*v,"soft clip: %s", 0, 1, 1, 1) ;
+	T_SimpleList<UIField>::Insert(f3) ;
+
 	position._y+=2 ;
 	UIActionField *a1=new UIActionField("Compact Sequencer",ACTION_PURGE,position) ;
 	a1->AddObserver(*this) ;
@@ -143,8 +149,8 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 	v=project_->FindVariable(VAR_MIDIDEVICE) ;
 	NAssert(v) ;
 	position._y+=2 ;
-	UIIntVarField *f3=new UIIntVarField(position,*v,"MIDI: %s",0,MidiService::GetInstance()->Size(),1,1) ;
-	T_SimpleList<UIField>::Insert(f3) ;
+	UIIntVarField *f4=new UIIntVarField(position,*v,"MIDI: %s",0,MidiService::GetInstance()->Size(),1,1) ;
+	T_SimpleList<UIField>::Insert(f4) ;
 
 	position._y+=2 ;
 	a1=new UIActionField("Exit",ACTION_QUIT,position) ;
@@ -218,7 +224,6 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 		focus=tempoField_ ;
 	}
 	Player *player=Player::GetInstance() ;
-
 	switch (fourcc) {
 		case ACTION_PURGE:
 			project_->Purge() ;

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -1,14 +1,14 @@
 #include "ProjectView.h"
-#include "BaseClasses/UIIntVarField.h"
-#include "BaseClasses/UIActionField.h"
-#include "BaseClasses/UIField.h"
-#include "BaseClasses/UITempoField.h"
 #include "Application/Persistency/PersistencyService.h"
-#include "System/System/System.h"
-#include "Services/Midi/MidiService.h"
 #include "Application/Views/ModalDialogs/MessageBox.h"
 #include "Application/Views/ModalDialogs/NewProjectDialog.h"
 #include "Application/Views/ModalDialogs/SelectProjectDialog.h"
+#include "BaseClasses/UIActionField.h"
+#include "BaseClasses/UIField.h"
+#include "BaseClasses/UIIntVarField.h"
+#include "BaseClasses/UITempoField.h"
+#include "Services/Midi/MidiService.h"
+#include "System/System/System.h"
 
 #define ACTION_PURGE            MAKE_FOURCC('P','U','R','G')
 #define ACTION_SAVE             MAKE_FOURCC('S','A','V','E')
@@ -116,50 +116,50 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 	UIIntVarField *f2=new UIIntVarField(position,*v,"transpose: %3.2d",-48,48,0x1,0xC) ;
 	T_SimpleList<UIField>::Insert(f2) ;
 
-	v=project_->FindVariable(VAR_SOFTCLIP) ;
-  position._y+=1 ;
-  UIIntVarField *f3 =
-      new UIIntVarField(position, *v, "soft clip: %s", 0, 4, 1, 1);
-  T_SimpleList<UIField>::Insert(f3);
+    v = project_->FindVariable(VAR_SOFTCLIP);
+    position._y += 1;
+    UIIntVarField *f3 =
+        new UIIntVarField(position, *v, "soft clip: %s", 0, 4, 1, 1);
+    T_SimpleList<UIField>::Insert(f3);
 
-  position._y += 2;
-  UIActionField *a1 =
-      new UIActionField("Compact Sequencer", ACTION_PURGE, position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 2;
+    UIActionField *a1 =
+        new UIActionField("Compact Sequencer", ACTION_PURGE, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
-  position._y += 1;
-  a1 = new UIActionField("Compact Instruments", ACTION_PURGE_INSTRUMENT,
-                         position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 1;
+    a1 = new UIActionField("Compact Instruments", ACTION_PURGE_INSTRUMENT,
+                           position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
-  position._y += 2;
-  a1 = new UIActionField("Load Song", ACTION_LOAD, position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 2;
+    a1 = new UIActionField("Load Song", ACTION_LOAD, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
-  position._y += 1;
-  a1 = new UIActionField("Save Song", ACTION_SAVE, position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 1;
+    a1 = new UIActionField("Save Song", ACTION_SAVE, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
-  position._y += 1;
-  a1 = new UIActionField("Save Song As", ACTION_SAVE_AS, position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 1;
+    a1 = new UIActionField("Save Song As", ACTION_SAVE_AS, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
-  v = project_->FindVariable(VAR_MIDIDEVICE);
-  NAssert(v);
-  position._y += 2;
-  UIIntVarField *f4 = new UIIntVarField(
-      position, *v, "MIDI: %s", 0, MidiService::GetInstance()->Size(), 1, 1);
-  T_SimpleList<UIField>::Insert(f4);
+    v = project_->FindVariable(VAR_MIDIDEVICE);
+    NAssert(v);
+    position._y += 2;
+    UIIntVarField *f4 = new UIIntVarField(
+        position, *v, "MIDI: %s", 0, MidiService::GetInstance()->Size(), 1, 1);
+    T_SimpleList<UIField>::Insert(f4);
 
-  position._y += 2;
-  a1 = new UIActionField("Exit", ACTION_QUIT, position);
-  a1->AddObserver(*this);
-  T_SimpleList<UIField>::Insert(a1);
+    position._y += 2;
+    a1 = new UIActionField("Exit", ACTION_QUIT, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
 
 }
 
@@ -227,8 +227,8 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 	} else {
 		focus=tempoField_ ;
 	}
-	Player *player=Player::GetInstance() ;
-	switch (fourcc) {
+    Player *player = Player::GetInstance();
+    switch (fourcc) {
 		case ACTION_PURGE:
 			project_->Purge() ;
 			break ;

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -118,44 +118,48 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 
 	v=project_->FindVariable(VAR_SOFTCLIP) ;
   position._y+=1 ;
-	UIIntVarField *f3=new UIIntVarField(position,*v,"soft clip: %s", 0, 1, 1, 1) ;
-	T_SimpleList<UIField>::Insert(f3) ;
+  UIIntVarField *f3 =
+      new UIIntVarField(position, *v, "soft clip: %s", 0, 4, 1, 1);
+  T_SimpleList<UIField>::Insert(f3);
 
-	position._y+=2 ;
-	UIActionField *a1=new UIActionField("Compact Sequencer",ACTION_PURGE,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 2;
+  UIActionField *a1 =
+      new UIActionField("Compact Sequencer", ACTION_PURGE, position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
-	position._y+=1 ;
-	a1=new UIActionField("Compact Instruments",ACTION_PURGE_INSTRUMENT,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 1;
+  a1 = new UIActionField("Compact Instruments", ACTION_PURGE_INSTRUMENT,
+                         position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
-	position._y+=2 ;
-	a1=new UIActionField("Load Song",ACTION_LOAD,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 2;
+  a1 = new UIActionField("Load Song", ACTION_LOAD, position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
-	position._y+=1 ;
-	a1=new UIActionField("Save Song",ACTION_SAVE,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 1;
+  a1 = new UIActionField("Save Song", ACTION_SAVE, position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
-	position._y+=1 ;
-	a1=new UIActionField("Save Song As",ACTION_SAVE_AS,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 1;
+  a1 = new UIActionField("Save Song As", ACTION_SAVE_AS, position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
-	v=project_->FindVariable(VAR_MIDIDEVICE) ;
-	NAssert(v) ;
-	position._y+=2 ;
-	UIIntVarField *f4=new UIIntVarField(position,*v,"MIDI: %s",0,MidiService::GetInstance()->Size(),1,1) ;
-	T_SimpleList<UIField>::Insert(f4) ;
+  v = project_->FindVariable(VAR_MIDIDEVICE);
+  NAssert(v);
+  position._y += 2;
+  UIIntVarField *f4 = new UIIntVarField(
+      position, *v, "MIDI: %s", 0, MidiService::GetInstance()->Size(), 1, 1);
+  T_SimpleList<UIField>::Insert(f4);
 
-	position._y+=2 ;
-	a1=new UIActionField("Exit",ACTION_QUIT,position) ;
-	a1->AddObserver(*this) ;
-	T_SimpleList<UIField>::Insert(a1) ;
+  position._y += 2;
+  a1 = new UIActionField("Exit", ACTION_QUIT, position);
+  a1->AddObserver(*this);
+  T_SimpleList<UIField>::Insert(a1);
 
 }
 

--- a/sources/Services/Audio/AudioOut.h
+++ b/sources/Services/Audio/AudioOut.h
@@ -18,7 +18,7 @@ public:
    virtual bool Start()=0 ;
    virtual void Stop()=0 ;
 
-   virtual void SetSoftclip(int clip)=0;
+   virtual void SetSoftclip(int clip) = 0;
 
    virtual void Trigger()=0 ;
 

--- a/sources/Services/Audio/AudioOut.h
+++ b/sources/Services/Audio/AudioOut.h
@@ -18,7 +18,7 @@ public:
    virtual bool Start()=0 ;
    virtual void Stop()=0 ;
 
-//       virtual void SetMasterVolume(int vol)=0 ;
+   virtual void SetSoftclip(int clip)=0;
 
    virtual void Trigger()=0 ;
 

--- a/sources/Services/Audio/AudioOutDriver.cpp
+++ b/sources/Services/Audio/AudioOutDriver.cpp
@@ -1,12 +1,12 @@
 
 #include "AudioOutDriver.h"
-#include "System/System/System.h"
-#include "AudioDriver.h"
 #include "Application/Model/Project.h"
 #include "Application/Player/SyncMaster.h" // Should be installable
-#include "System/Console/Trace.h"
+#include "AudioDriver.h"
 #include "Services/Time/TimeService.h"
-#include <math.h> 
+#include "System/Console/Trace.h"
+#include "System/System/System.h"
+#include <math.h>
 
 AudioOutDriver::AudioOutDriver(AudioDriver &driver) {
     maxPositiveFixed_ = i2fp(32767);
@@ -203,6 +203,4 @@ int AudioOutDriver::GetAudioPreBufferCount() {
 	AudioSettings as=driver_->GetAudioSettings() ;
 	return as.preBufferCount_ ;
 } ;
-double AudioOutDriver::GetStreamTime() {
-	return driver_->GetStreamTime() ;
-} ;
+double AudioOutDriver::GetStreamTime() { return driver_->GetStreamTime(); };

--- a/sources/Services/Audio/AudioOutDriver.h
+++ b/sources/Services/Audio/AudioOutDriver.h
@@ -20,6 +20,7 @@ public:
        virtual void Stop() ;
  
        virtual void Trigger() ;
+       virtual void SetSoftclip(int clip);
 
        virtual bool Clipped() ;
 
@@ -46,6 +47,7 @@ private:
         AudioDriver *driver_ ;
        	bool clipped_ ;
        	bool hasSound_ ;
+        bool softclip_ ;
 
 	    fixed *primarySoundBuffer_ ;
 	    short *mixBuffer_ ;

--- a/sources/Services/Audio/AudioOutDriver.h
+++ b/sources/Services/Audio/AudioOutDriver.h
@@ -10,47 +10,51 @@ class AudioDriver ;
 #define MIX_BUFFER_SIZE 40000
 
 class AudioOutDriver: public AudioOut,protected I_Observer {
-public:
-       AudioOutDriver(AudioDriver &) ;
-       virtual ~AudioOutDriver() ;
- 
-       virtual bool Init() ;
-       virtual void Close() ;
-       virtual bool Start() ;
-       virtual void Stop() ;
- 
-       virtual void Trigger() ;
-       virtual void SetSoftclip(int clip);
+  public:
+    AudioOutDriver(AudioDriver &) ;
+    virtual ~AudioOutDriver() ;
 
-       virtual bool Clipped() ;
+    virtual bool Init() ;
+    virtual void Close() ;
+    virtual bool Start() ;
+    virtual void Stop() ;
 
-	   virtual int GetPlayedBufferPercentage() ;
+    virtual void Trigger() ;
+    virtual void SetSoftclip(int clip);
 
-       AudioDriver *GetDriver() ;
+    virtual bool Clipped() ;
 
-		virtual std::string GetAudioAPI() ;
-		virtual std::string GetAudioDevice() ;
-		virtual int GetAudioBufferSize() ;
-		virtual int GetAudioRequestedBufferSize() ;
-		virtual int GetAudioPreBufferCount() ;
-		virtual double GetStreamTime() ;
+    virtual int GetPlayedBufferPercentage() ;
 
-protected:
+    AudioDriver *GetDriver() ;
 
-		virtual void Update(Observable &o,I_ObservableData *d) ;
- 
-       void prepareMixBuffers() ;
-       void mixToPrimary() ;
-	   void clipToMix() ;
+    virtual std::string GetAudioAPI() ;
+    virtual std::string GetAudioDevice() ;
+    virtual int GetAudioBufferSize() ;
+    virtual int GetAudioRequestedBufferSize() ;
+    virtual int GetAudioPreBufferCount() ;
+    virtual double GetStreamTime() ;
 
-private:
-        AudioDriver *driver_ ;
-       	bool clipped_ ;
-       	bool hasSound_ ;
-        bool softclip_ ;
+  protected:
 
-	    fixed *primarySoundBuffer_ ;
-	    short *mixBuffer_ ;
-	    int sampleCount_ ;       
+    virtual void Update(Observable &o,I_ObservableData *d) ;
+
+    void prepareMixBuffers() ;
+    void mixToPrimary() ;
+    void clipToMix() ;
+    fixed hardClip(fixed sample);
+    fixed softClip(fixed sample);
+
+  private:
+    AudioDriver *driver_ ;
+    bool clipped_ ;
+    bool hasSound_ ;
+    int softclip_ ;
+    fixed maxPositiveFixed_;
+    fixed maxNegativeFixed_;
+
+    fixed *primarySoundBuffer_ ;
+    short *mixBuffer_ ;
+    int sampleCount_ ;       
 } ;
 #endif


### PR DESCRIPTION
Implements #106. Project screen now has a "soft clip" option, which is saved per-project. I implemented [cubic soft clip](https://wiki.analog.com/resources/tools-software/sigmastudio/toolbox/nonlinearprocessors/standardcubic) to the best of my ability. It has four "modes" of varying hardness, which correspond to ceilings of roughly -1.5/-3/-6/-9db respectively. I also tried to gain compensate it, so switching it on increases overall loudness by the same amount. It goes before already existing hard clip, so turning it off (default) should sound exactly the same as before.

![softclip](https://github.com/user-attachments/assets/3df15b1e-9ef8-490e-9adb-869c6b02ab5e)

Videos of it in action: 
https://www.youtube.com/watch?v=W3pbEFrTkyg
https://www.youtube.com/watch?v=ZRu2YkMA9MM

All of the modes on sine wave at 0db peak: 
![image](https://github.com/user-attachments/assets/d37772b2-0b78-4e34-acc7-2cf8d3c25882)

Should cover most needs, I think. One existing quirk is the Master Volume being Input Gain of the clipper, it might be a good idea to add an "Output" volume that only goes downwards so one could balance their Piggy tracks volume-wise when preparing for dj sets, etc.

This is the first time I dabble in both C++ and audio processing, so this is ugly and I apologize. It works surprisingly well though. One ugly thing that remains is passing project's softclip variable into AudioOutDriver; at this point I don't know how to do it better. I had to set up `SetSoftclip()` method in both Mixer and AudioOut to pass the variable, and I had to create an empty `DummyAudioOut::SetSoftclip` method to circumvent the "invalid new expression of abstract class type <...> because the following virtual functions are pure within" compilation error.

Tested it under Linux x64, on Powkiddy V90 (bittboy), and Miyoo Mini (miyoo).

Let me know what you think! I appreciate any input or insight on how to make things better :)

I also fixed spacebar mapping for X64.