### PR TITLE
Remove drawing optimization that causes flashing in Song view

### DIFF
--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1012,15 +1012,13 @@ void SongView::DrawView() {
 };
 
 /******************************************************
- OnPlayterUpdate:
+ OnPlayerUpdate:
         Called when positions in player change. Should
         provide visual feedback of currently played
         position
  ******************************************************/
 
 void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
-
-    SyncMaster *sync = SyncMaster::GetInstance();
 
     Player *player = Player::GetInstance();
 

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1021,8 +1021,6 @@ void SongView::DrawView() {
 void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
     SyncMaster *sync = SyncMaster::GetInstance();
-    if ((eventType == PET_UPDATE) && (!sync->MajorSlice()))
-        return;
 
     Player *player = Player::GetInstance();
 


### PR DESCRIPTION
All of the play cursors and the right sidebar flash in and out of existence on every key press in Song view, even if the keypress does nothing at all.

Turns out the removed piece of code is responsible for it; it appears to be some sort of drawing optimization, because it makes LGPT to redraw these parts only once per so-called "major slice" of audio if I'm not mistaken. But it doesn't take into account that play cursors and the sidebar get cleared when everything before them gets drawn on screen, and as the result they flash once per slice.

It still does unneccessary redraws though, I think the better way to do it would be to rewrite drawing logic to not wipe the whole screen all the time and redraw play cursors only when scrolling or when current chain changes, and the sidebar should be split and updated separately, timer once per second, and clip indicator as soon as clipping occur.

But just redrawing it more times doesn't seem to be such a bad idea and it's easy to do. Because it does look like optimization to me I tried to run Piggy without this code on the V90 which is the weakest device I own (~700mhz single-core cpu), and I haven't noticed any difference in performance so far.

This bug has been a thing since forever and it's a major annoyance for me personally, would love to have it fixed, I'd gladly give up a bit of optimization to get rid of the flashing

Let me know what you think and if I missed anything important!