### PR TITLE
Bad WAV/fmt format importing some .wavs

### DIFF
--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -125,14 +125,6 @@ WavFile *WavFile::Open(const char *path) {
 
     // Read (possible) JUNK
 
-    // Read fmt or JUNK
-
-    position += wav->readBlock(position, 4);
-    memcpy(&chunk, wav->readBuffer_, 4);
-    chunk = Swap32(chunk);
-
-    // Read (possible) JUNK
-
     #ifndef NOSKIPJUNK
     if (chunk==0x4b4e554a) {
         position += wav->readBlock(position, 4);

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -117,13 +117,21 @@ WavFile *WavFile::Open(const char *path) {
 		return 0 ;
 	}
 
-// Read fmt or JUNK
+    // Read fmt or JUNK
 
-position += wav->readBlock(position, 4);
-memcpy(&chunk, wav->readBuffer_, 4);
-chunk = Swap32(chunk);
+    position += wav->readBlock(position, 4);
+    memcpy(&chunk, wav->readBuffer_, 4);
+    chunk = Swap32(chunk);
 
-// Read (possible) JUNK
+    // Read (possible) JUNK
+
+    // Read fmt or JUNK
+
+    position += wav->readBlock(position, 4);
+    memcpy(&chunk, wav->readBuffer_, 4);
+    chunk = Swap32(chunk);
+
+    // Read (possible) JUNK
 
     #ifndef NOSKIPJUNK
     if (chunk==0x4b4e554a) {

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -117,13 +117,13 @@ WavFile *WavFile::Open(const char *path) {
 		return 0 ;
 	}
 
-    // Read fmt or JUNK
+// Read fmt or JUNK
 
-    position+=wav->readBlock(position,4) ;
-	memcpy(&chunk,wav->readBuffer_,4) ;
-	chunk = Swap32(chunk);
+position += wav->readBlock(position, 4);
+memcpy(&chunk, wav->readBuffer_, 4);
+chunk = Swap32(chunk);
 
-    // Read (possible) JUNK
+// Read (possible) JUNK
 
     #ifndef NOSKIPJUNK
     if (chunk==0x4b4e554a) {

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -117,34 +117,34 @@ WavFile *WavFile::Open(const char *path) {
 		return 0 ;
 	}
 
-    	// Read fmt or JUNK
+    // Read fmt or JUNK
 
-   	position+=wav->readBlock(position,4) ;
+    position+=wav->readBlock(position,4) ;
 	memcpy(&chunk,wav->readBuffer_,4) ;
 	chunk = Swap32(chunk);
 
-    	// Read (possible) JUNK
+    // Read (possible) JUNK
 
-	#ifndef NOSKIPJUNK
-	if (chunk==0x4b4e554a) {
+    #ifndef NOSKIPJUNK
+    if (chunk==0x4b4e554a) {
 		position+=wav->readBlock(position,4) ;
-        memcpy(&chunk, wav->readBuffer_,4) ;
-        chunk = Swap32(chunk) ;
-        // Avoid out-of-bounds read
-        if (chunk > size-position) {
-            Trace::Error("Bad WAV format: wrong JUNK size") ;
-            delete wav ;
-			return 0 ;
+		memcpy(&chunk, wav->readBuffer_,4) ;
+		chunk = Swap32(chunk) ;
+		// Avoid out-of-bounds read
+		if (chunk > size-position) {
+		    Trace::Error("Bad WAV format: wrong JUNK size") ;
+		    delete wav ;
+		    return 0 ;
 		}
-        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", chunk);
-        position+=wav->readBlock(position,chunk) ;
-	   	position+=wav->readBlock(position,4) ;
+		// Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", chunk);
+		position+=wav->readBlock(position,chunk) ;
+		position+=wav->readBlock(position,4) ;
 		memcpy(&chunk,wav->readBuffer_,4) ;
 		chunk = Swap32(chunk);
-	}
-	#endif
+    }
+    #endif
 
-    	// Read fmt
+    // Read fmt
 
     if (chunk!=0x20746D66) {
 		Trace::Error("Bad WAV/fmt format") ;

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -127,20 +127,20 @@ WavFile *WavFile::Open(const char *path) {
 
     #ifndef NOSKIPJUNK
     if (chunk==0x4b4e554a) {
-		position+=wav->readBlock(position,4) ;
-		memcpy(&chunk, wav->readBuffer_,4) ;
-		chunk = Swap32(chunk) ;
-		// Avoid out-of-bounds read
-		if (chunk > size-position) {
-		    Trace::Error("Bad WAV format: wrong JUNK size") ;
-		    delete wav ;
-		    return 0 ;
-		}
-		// Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", chunk);
-		position+=wav->readBlock(position,chunk) ;
-		position+=wav->readBlock(position,4) ;
-		memcpy(&chunk,wav->readBuffer_,4) ;
-		chunk = Swap32(chunk);
+        position += wav->readBlock(position, 4);
+        memcpy(&chunk, wav->readBuffer_,4) ;
+        chunk = Swap32(chunk) ;
+        // Avoid out-of-bounds read
+        if (chunk > size-position) {
+            Trace::Error("Bad WAV format: wrong JUNK size") ;
+            delete wav ;
+            return 0 ;
+        }
+        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", chunk);
+        position+=wav->readBlock(position,chunk) ;
+        position+=wav->readBlock(position,4) ;
+        memcpy(&chunk,wav->readBuffer_,4) ;
+        chunk = Swap32(chunk);
     }
     #endif
 

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -117,13 +117,30 @@ WavFile *WavFile::Open(const char *path) {
 		return 0 ;
 	}
 
-		// Read fmt
+    	// Read fmt or JUNK
 
-	position+=wav->readBlock(position,4) ;
+   	position+=wav->readBlock(position,4) ;
 	memcpy(&chunk,wav->readBuffer_,4) ;
 	chunk = Swap32(chunk);
-		
-	if (chunk!=0x20746D66) {
+
+    	// Read (possible) JUNK
+
+	#ifndef NOSKIPJUNK
+	if (chunk==0x4b4e554a) {
+		position+=wav->readBlock(position,4) ;
+        memcpy(&size, wav->readBuffer_,4) ;
+        size = Swap32(size) ;
+        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", size);
+        position+=size;
+	   	position+=wav->readBlock(position,4) ;
+		memcpy(&chunk,wav->readBuffer_,4) ;
+		chunk = Swap32(chunk);
+	}
+	#endif
+
+    	// Read fmt
+
+    if (chunk!=0x20746D66) {
 		Trace::Error("Bad WAV/fmt format") ;
 		delete wav ;
 		return 0 ;

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -128,10 +128,16 @@ WavFile *WavFile::Open(const char *path) {
 	#ifndef NOSKIPJUNK
 	if (chunk==0x4b4e554a) {
 		position+=wav->readBlock(position,4) ;
-        memcpy(&size, wav->readBuffer_,4) ;
-        size = Swap32(size) ;
-        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", size);
-        position+=size;
+        memcpy(&chunk, wav->readBuffer_,4) ;
+        chunk = Swap32(chunk) ;
+        // Avoid out-of-bounds read
+        if (chunk > size-position) {
+            Trace::Error("Bad WAV format: wrong JUNK size") ;
+            delete wav ;
+			return 0 ;
+		}
+        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", chunk);
+        position+=wav->readBlock(position,chunk) ;
 	   	position+=wav->readBlock(position,4) ;
 		memcpy(&chunk,wav->readBuffer_,4) ;
 		chunk = Swap32(chunk);


### PR DESCRIPTION
The format validation for .wav files is a bit too restrictive and somewhat wrong. This patch should allow for most .wav to be loaded as samples.