### PR TITLE
Enable to skip JUNK chunk when reading a WAV

### DIFF
--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -117,13 +117,30 @@ WavFile *WavFile::Open(const char *path) {
 		return 0 ;
 	}
 
-		// Read fmt
+    // Read fmt or JUNK
 
-	position+=wav->readBlock(position,4) ;
-	memcpy(&chunk,wav->readBuffer_,4) ;
+    position += wav->readBlock(position, 4);
+    memcpy(&chunk,wav->readBuffer_,4) ;
 	chunk = Swap32(chunk);
-		
-	if (chunk!=0x20746D66) {
+
+        // Read (possible) JUNK
+
+	#ifndef NOSKIPJUNK
+	if (chunk==0x4b4e554a) {
+		position+=wav->readBlock(position,4) ;
+        memcpy(&size, wav->readBuffer_,4) ;
+        size = Swap32(size) ;
+        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", size);
+        position+=size;
+	   	position+=wav->readBlock(position,4) ;
+		memcpy(&chunk,wav->readBuffer_,4) ;
+		chunk = Swap32(chunk);
+	}
+	#endif
+
+    	// Read fmt
+
+    if (chunk!=0x20746D66) {
 		Trace::Error("Bad WAV/fmt format") ;
 		delete wav ;
 		return 0 ;

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -125,20 +125,18 @@ WavFile *WavFile::Open(const char *path) {
 
         // Read (possible) JUNK
 
-	#ifndef NOSKIPJUNK
-	if (chunk==0x4b4e554a) {
-		position+=wav->readBlock(position,4) ;
+    if (chunk == 0x4b4e554a) {
+        position+=wav->readBlock(position,4) ;
         memcpy(&size, wav->readBuffer_,4) ;
         size = Swap32(size) ;
-        // Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", size);
+        Trace::Debug("WavFile::Open(): skipping JUNK with size=%d", size);
         position+=size;
-	   	position+=wav->readBlock(position,4) ;
-		memcpy(&chunk,wav->readBuffer_,4) ;
+        position += wav->readBlock(position, 4);
+        memcpy(&chunk,wav->readBuffer_,4) ;
 		chunk = Swap32(chunk);
-	}
-	#endif
+    }
 
-    	// Read fmt
+    // Read fmt
 
     if (chunk!=0x20746D66) {
 		Trace::Error("Bad WAV/fmt format") ;


### PR DESCRIPTION
Enables to skip the "JUNK" section when reading a WAV sample (https://www.daubnet.com/en/file-format-riff).

This extra chunk before "fmt" and that should be skipped appears in samples ripped from CDs: apparently CD-player can only move in certain increments and data that should be skipped makes sure that the start of audio data aligns with what player expects. Is this chunk useless nowdays? - absolutely. Will it help to be able to load old samples? - i think it will. As mentioned before half of my goto samples library cant be loaded because of this.