### PR TITLE
Remove double crush drive in InstrumentView

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -121,15 +121,8 @@ void InstrumentView::fillSampleParameters() {
 	f1=new UIIntVarField(position,*v,"detune: %2.2X",0,255,1,0x10) ;
 	T_SimpleList<UIField>::Insert(f1) ;
 
-
-	position._y+=2 ;
-	v=instrument->FindVariable(SIP_CRUSHVOL) ;
-	f1=new UIIntVarField(position,*v,"drive: %2.2X",0,0xFF,1,0x10) ;
-	T_SimpleList<UIField>::Insert(f1) ;
-
-
-	position._y+=1 ;
-	v=instrument->FindVariable(SIP_CRUSH) ;
+    position._y += 2;
+    v=instrument->FindVariable(SIP_CRUSH);
 	f1=new UIIntVarField(position,*v,"crush: %d",1,0x10,1,4) ;
 	T_SimpleList<UIField>::Insert(f1) ;
 


### PR DESCRIPTION
Crush drive was reverted in https://github.com/djdiskmachine/LittleGPTracker/pull/151 and not re-added in https://github.com/djdiskmachine/LittleGPTracker/pull/155