### PR TITLE
Consistent view title separators

### DIFF
--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -811,8 +811,8 @@ void ChainView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
     pos._x += 200;
 /*
 	if (player->Clipped()) {
-           w_.DrawString("clip",pos,props); 
+           w_.DrawString("clip",pos,props);
     } else {
-           w_.DrawString("----",pos,props); 
+           w_.DrawString("----",pos,props);
     }
 */} ;

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -8,8 +8,7 @@ GrooveView::GrooveView(GUIWindow &w,ViewData *viewData):View(w,viewData) {
 	lastPosition_=0 ;
 }
 
-GrooveView::~GrooveView() {
-} 
+GrooveView::~GrooveView() {}
 
 void GrooveView::updateCursor(int dir) {
 	position_+=dir ;
@@ -25,8 +24,8 @@ void GrooveView::updateCursorValue(int val,bool sync) {
 	if (val<1) val=1 ;
 	if (val>0xF) val=0xF ;
 	grooveData[position_]=val ;
-	isDirty_=true; 
-} ;
+    isDirty_ = true;
+};
 
 void GrooveView::warpGroove(int dir) {
 	int current=viewData_->currentGroove_ ;
@@ -53,19 +52,20 @@ void GrooveView::clearCursorValue() {
 	unsigned char *grooveData=Groove::GetInstance()->GetGrooveData(viewData_->currentGroove_) ;
 	grooveData[position_]=NO_GROOVE_DATA ;
 	isDirty_=true ;
-}	
+}
 
 void GrooveView::ProcessButtonMask(unsigned short mask,bool pressed) {
 
-	if (!pressed) return ;
-	
-	Player *player=Player::GetInstance() ;
+    if (!pressed)
+        return;
 
-	if (mask&EPBM_B) {         
-			if (mask&EPBM_LEFT) {
-				warpGroove(-1) ;
-			}
-			if (mask&EPBM_RIGHT) {
+    Player *player = Player::GetInstance();
+
+    if (mask&EPBM_B) {
+        if (mask & EPBM_LEFT) {
+            warpGroove(-1);
+        }
+            if (mask&EPBM_RIGHT) {
 				warpGroove(1) ;
 			}
 			if (mask&EPBM_DOWN) {
@@ -79,12 +79,12 @@ void GrooveView::ProcessButtonMask(unsigned short mask,bool pressed) {
 			} ;
 	} else {
 
-	  // A modifier
-	  if (mask&EPBM_A) {         
-			if (mask&EPBM_LEFT) {
-				updateCursorValue(-1) ;
-			}
-			if (mask&EPBM_RIGHT) {
+        // A modifier
+        if (mask & EPBM_A) {
+            if (mask & EPBM_LEFT) {
+                updateCursorValue(-1);
+            }
+            if (mask&EPBM_RIGHT) {
 				updateCursorValue(1) ;
 			}
 			if (mask&EPBM_DOWN) {
@@ -107,20 +107,20 @@ void GrooveView::ProcessButtonMask(unsigned short mask,bool pressed) {
 					NotifyObservers(&ve) ;
 				}
 				if (mask&EPBM_START) {
-					player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
-    			}			
+                    player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
+                                          viewData_->chainRow_);
+                }
 
-	    	} else {
+            } else {
                 // No modifier
     			if (mask&EPBM_DOWN) updateCursor(1) ;
     			if (mask&EPBM_UP) updateCursor(-1) ;
     			if (mask&EPBM_START) {
 					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
-    			}
-		    }
-	  } 
-	    
-	}
+                }
+            }
+      }
+    }
 } ;
 
 void GrooveView::DrawView() {
@@ -134,18 +134,17 @@ void GrooveView::DrawView() {
 
 	char title[40] ;
 
-	SetColor(CD_NORMAL) ;
-
-	sprintf(title,"Groove: %2.2x",viewData_->currentGroove_) ;
+    SetColor(CD_NORMAL);
+    sprintf(title,"Groove %2.2x", viewData_->currentGroove_) ;
 	DrawString(pos._x,pos._y,title,props) ;
 
 // Compute song grid location
 
-	GUIPoint anchor=GetAnchor() ;
-	
-// Display row numbers
+    GUIPoint anchor = GetAnchor();
 
-	char buffer[6] ;
+    // Display row numbers
+
+    char buffer[6] ;
 	pos=anchor ;
 	pos._x-=3 ;
 	for (int j=0;j<16;j++) {
@@ -168,12 +167,12 @@ void GrooveView::DrawView() {
 			hex2char(grooveData[j],buffer) ;
 			buffer[3]=0 ;
 		} else {
-			strcpy(buffer,"--") ;
-		} ;
-		props.invert_=(j==position_) ; 
-		DrawString(pos._x,pos._y,buffer,props) ;
-		pos._y++ ;
-	}
+            strcpy(buffer, "--");
+        } ;
+        props.invert_ = (j == position_);
+        DrawString(pos._x,pos._y,buffer,props) ;
+        pos._y++;
+    }
 
 	drawMap() ;
 	drawNotes() ;
@@ -186,12 +185,12 @@ void GrooveView::OnPlayerUpdate(PlayerEventType ,unsigned int tick) {
 	GUIPoint pos ;
 
 	pos._x=anchor._x-1 ;
-	pos._y=anchor._y+lastPosition_ ;
-	DrawString(pos._x,pos._y," ",props) ;
-		
-	Groove *gr=Groove::GetInstance() ;
-	// Get current channel
-	int channel=viewData_->songX_ ;
+    pos._y = anchor._y + lastPosition_;
+    DrawString(pos._x,pos._y," ",props) ;
+
+    Groove *gr=Groove::GetInstance() ;
+    // Get current channel
+    int channel=viewData_->songX_ ;
 
 	int groove ;
 	int groovepos ;

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -46,8 +46,8 @@ void InstrumentView::onInstrumentChange() {
 	T_SimpleList<UIField>::Empty() ;
 
 	InstrumentType it=getInstrumentType() ;
- 
- 	switch (it) {
+
+    switch (it) {
 		case IT_MIDI:
 			fillMidiParameters() ;
 			break ;
@@ -77,7 +77,7 @@ void InstrumentView::fillSampleParameters() {
 	I_Instrument *instr=bank->GetInstrument(i) ;
 	SampleInstrument *instrument=(SampleInstrument *)instr  ;
 	GUIPoint position=GetAnchor() ;
-	
+
 //	position._y+=View::fieldSpaceHeight_;
 	Variable *v=instrument->FindVariable(SIP_SAMPLE) ;
 	SamplePool *sp=SamplePool::GetInstance() ;
@@ -90,11 +90,11 @@ void InstrumentView::fillSampleParameters() {
     f1 = new UIIntVarField(position, *v, "%s", 0, 3, 1, 2);
     T_SimpleList<UIField>::Insert(f1) ;
 
-    position._x += 8;
+    position._x += 7;
     v = instrument->FindVariable(SIP_IR_WET);
     f1 = new UIIntVarField(position, *v, "wet:%d%%", 0, 100, 1, 10);
     T_SimpleList<UIField>::Insert(f1);
-    position._x += 8;
+    position._x += 9;
 
     v = instrument->FindVariable(SIP_IR_PAD);
     f1 = new UIIntVarField(position, *v, "pad:%dms", 0, 5000, 5, 100);
@@ -105,8 +105,8 @@ void InstrumentView::fillSampleParameters() {
     v=instrument->FindVariable(SIP_VOLUME) ;
 	f1=new UIIntVarField(position,*v,"volume: %d [%2.2X]",0,255,1,10) ;
 	T_SimpleList<UIField>::Insert(f1) ;
-	
-	position._y+=1 ;
+
+    position._y+=1 ;
 	v=instrument->FindVariable(SIP_PAN) ;
 	f1=new UIIntVarField(position,*v,"pan: %2.2X",0,0xFE,1,0x10) ;
 	T_SimpleList<UIField>::Insert(f1) ;
@@ -188,8 +188,8 @@ void InstrumentView::fillSampleParameters() {
 	v=instrument->FindVariable(SIP_INTERPOLATION) ;
 	f1=new UIIntVarField(position,*v,"interpolation: %s",0,1,1,1) ;
 	T_SimpleList<UIField>::Insert(f1) ;
-	
-	position._y+=1 ;
+
+    position._y+=1 ;
 	v=instrument->FindVariable(SIP_LOOPMODE) ;
 	f1=new UIIntVarField(position,*v,"loop mode: %s",0,SILM_LAST-1,1,1) ;
 	T_SimpleList<UIField>::Insert(f1) ;
@@ -347,12 +347,12 @@ void InstrumentView::ProcessButtonMask(unsigned short mask,bool pressed) {
 	}
 
 	FieldView::ProcessButtonMask(mask) ;
-	
-	Player *player=Player::GetInstance() ;
+
+    Player *player=Player::GetInstance() ;
 	// B Modifier
 
-	if (mask&EPBM_B) {         
-		if (mask&EPBM_LEFT) warpToNext(-1) ;
+    if (mask & EPBM_B) {
+        if (mask&EPBM_LEFT) warpToNext(-1) ;
 		if (mask&EPBM_RIGHT) warpToNext(+1);
 		if (mask&EPBM_DOWN) warpToNext(-16) ;
 		if (mask&EPBM_UP) warpToNext(+16);
@@ -382,21 +382,21 @@ void InstrumentView::ProcessButtonMask(unsigned short mask,bool pressed) {
         if (mask&EPBM_L) {
             viewMode_=VM_CLONE ;
         } ;
-	} else {
+    } else {
 
-	  // A modifier
+        // A modifier
 
-	  if (mask==EPBM_A) {
-			FourCC varID=((UIIntVarField *)GetFocus())->GetVariableID() ;
+        if (mask == EPBM_A) {
+            FourCC varID=((UIIntVarField *)GetFocus())->GetVariableID() ;
 			if ((varID==SIP_TABLE)||(varID==MIP_TABLE)||(varID==SIP_SAMPLE)) {
 				viewMode_=VM_NEW ;
 			} ;
-	  } else {
+        } else {
 
-		  // R Modifier
+            // R Modifier
 
-          	if (mask&EPBM_R) {
-				if (mask&EPBM_LEFT) {
+            if (mask & EPBM_R) {
+                if (mask&EPBM_LEFT) {
 					ViewType vt=VT_PHRASE;
 					ViewEvent ve(VET_SWITCH_VIEW,&vt) ;
 					SetChanged();
@@ -436,18 +436,17 @@ void InstrumentView::ProcessButtonMask(unsigned short mask,bool pressed) {
         		if (mask&EPBM_START) {
 	   			    player->OnStartButton(PM_PHRASE,viewData_->songX_,true,viewData_->chainRow_) ;
         		}
-	    	} else {
+            } else {
                 // No modifier
     			if (mask&EPBM_START) {
 					player->OnStartButton(PM_PHRASE,viewData_->songX_,false,viewData_->chainRow_) ;
     			}
-		    }
-	  } 
-	    
-	}
+            }
+        }
+    }
 
-	UIIntVarField *field=(UIIntVarField *)GetFocus() ;
-	if (field) {
+    UIIntVarField *field = (UIIntVarField *)GetFocus();
+    if (field) {
 	   lastFocusID_=field->GetVariableID() ;
     }
 
@@ -465,19 +464,16 @@ void InstrumentView::DrawView() {
 
     char title[20];
     SetColor(CD_NORMAL) ;
-	sprintf(title,"Instrument %2.2X",viewData_->currentInstrument_) ;
-	DrawString(pos._x,pos._y,title,props) ;
+    sprintf(title, "Instrument %2.2X", viewData_->currentInstrument_);
+    DrawString(pos._x, pos._y, title, props);
 
-// Draw fields
+    // Draw fields
 
-	FieldView::Redraw() ;
-	drawMap() ;
+    FieldView::Redraw();
+    drawMap() ;
 } ;
 
-void InstrumentView::OnFocus() {
-    onInstrumentChange() ; 
-}
-
+void InstrumentView::OnFocus() { onInstrumentChange(); }
 
 void InstrumentView::Update(Observable &o,I_ObservableData *d) {
 	onInstrumentChange() ;

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -100,8 +100,8 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 	project_=data->project_ ;
 
 	GUIPoint position=GetAnchor() ;
-	
-	Variable *v=project_->FindVariable(VAR_TEMPO) ;
+
+    Variable *v=project_->FindVariable(VAR_TEMPO) ;
 	UITempoField *f=new UITempoField(ACTION_TEMPO_CHANGED,position,*v,"tempo: %d [%2.2x]  ",60,400,1,10) ;
 	T_SimpleList<UIField>::Insert(f) ;
 	f->AddObserver(*this) ;
@@ -128,8 +128,8 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
     position._y+=2 ;
 	UIIntVarField *f2=new UIIntVarField(position,*v,"transpose: %3.2d",-48,48,0x1,0xC) ;
 	T_SimpleList<UIField>::Insert(f2) ;
-	
-	v = project_->FindVariable(VAR_SCALE);
+
+    v = project_->FindVariable(VAR_SCALE);
 	// if scale name is not found, set the default chromatic scale
 	if (v->GetInt() < 0) {
 		v->SetInt(0);
@@ -205,8 +205,8 @@ void ProjectView::ProcessButtonMask(unsigned short mask,bool pressed) {
 } ;
 
 void ProjectView::DrawView() {
-   
-	Clear() ;
+
+    Clear() ;
 
 	GUITextProperties props ;
 	GUIPoint pos=GetTitlePosition() ;
@@ -214,10 +214,11 @@ void ProjectView::DrawView() {
 // Draw title
 
 	char projectString[80] ;
-	sprintf(projectString,"Project - Build %s.%s.%s",PROJECT_NUMBER,PROJECT_RELEASE,BUILD_COUNT) ;
+    sprintf(projectString, "Project (Build %s.%s.%s)", PROJECT_NUMBER,
+            PROJECT_RELEASE, BUILD_COUNT);
 
-	SetColor(CD_NORMAL) ;
-	DrawString(pos._x,pos._y,projectString,props) ;
+    SetColor(CD_NORMAL);
+    DrawString(pos._x,pos._y,projectString,props) ;
 
 	FieldView::Redraw() ;
 	drawMap() ;

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -911,7 +911,7 @@ void SongView::DrawView() {
     std::ostringstream os;
 
     os << ((player->GetSequencerMode() == SM_SONG) ? "Song" : "Live");
-    os << " - ";
+    os << ": ";
     os << songname_;
     std::string buffer(os.str());
 


### PR DESCRIPTION
This PR does some small visual changes:

- `Song - WildClimb` -> `Song: WildClimb`
- `Chain 00` -> `Chain 00` (same)
- `Groove: 00` -> `Groove 00` (remove ":")
- `Project - Build v1.4.3` ->  `Project (Build v1.4.3)`
- _Instrument: `pad` shifted to the right a little bit to give `wet` more space if set to `100%`_