### PR TITLE
Softclip rework

### DIFF
--- a/sources/Application/Audio/DummyAudioOut.cpp
+++ b/sources/Application/Audio/DummyAudioOut.cpp
@@ -53,7 +53,8 @@ void DummyAudioOut::Stop() {
 	SAFE_DELETE(thread_) ;
 } ;
 
-void DummyAudioOut::SetSoftclip(int clip, int attn) {}
+void DummyAudioOut::SetSoftclip(int clip, int gain) {}
+void DummyAudioOut::SetMasterVolume(int volume) {}
 
 void DummyAudioOut::SendPulse()
 {

--- a/sources/Application/Audio/DummyAudioOut.h
+++ b/sources/Application/Audio/DummyAudioOut.h
@@ -41,6 +41,7 @@ public:
 	virtual int GetAudioPreBufferCount() ;
 	virtual double GetStreamTime() ;
     virtual void SetSoftclip(int, int);
+    virtual void SetMasterVolume(int);
 
   private:
     DummyOutThread *thread_ ;

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -160,7 +160,7 @@ bool MixerService::Clipped() {
      return out_->Clipped() ;
 } ;
 
-void MixerService::SetMasterVolume(int vol) {
+void MixerService::SetPregain(int vol) {
     Mixer *mixer = Mixer::GetInstance();
 
     fixed masterVolume = fp_mul(i2fp(vol), fl2fp(0.01f));
@@ -168,11 +168,13 @@ void MixerService::SetMasterVolume(int vol) {
     for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
         bus_[i].SetVolume(masterVolume);
   }
-} ;
+};
 
-void MixerService::SetSoftclip(int clip, int attn) {
-    out_->SetSoftclip(clip, attn);
+void MixerService::SetSoftclip(int clip, int gain) {
+    out_->SetSoftclip(clip, gain);
 }
+
+void MixerService::SetMasterVolume(int attn) { out_->SetMasterVolume(attn); }
 
 int MixerService::GetPlayedBufferPercentage() {
 	return out_->GetPlayedBufferPercentage() ;

--- a/sources/Application/Mixer/MixerService.h
+++ b/sources/Application/Mixer/MixerService.h
@@ -48,8 +48,9 @@ public:
 	void OnPlayerStop() ;
 
 	bool Clipped() ;
-	void SetMasterVolume(int) ;
+    void SetPregain(int);
     void SetSoftclip(int, int);
+    void SetMasterVolume(int);
     int GetPlayedBufferPercentage() ;
 	
 	virtual void Execute(FourCC id,float value) ;

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -20,21 +20,23 @@ Project::Project()
 ,midiDeviceList_(0),
 tempoNudge_(0)
 {
-
-	WatchedVariable *tempo=new WatchedVariable("tempo",VAR_TEMPO,138) ;
-	this->Insert(tempo) ;
-	Variable *masterVolume=new Variable("master",VAR_MASTERVOL,100) ;
-	this->Insert(masterVolume) ;
-	Variable *wrap=new Variable("wrap",VAR_WRAP,false) ;
-	this->Insert(wrap) ;
-	Variable *transpose=new Variable("transpose",VAR_TRANSPOSE,0) ;
-	this->Insert(transpose) ;
+    WatchedVariable *tempo = new WatchedVariable("tempo", VAR_TEMPO, 138);
+    this->Insert(tempo);
+    Variable *pregain =
+        new Variable("pregain", VAR_PREGAIN, 100, 200);
+    this->Insert(pregain);
     Variable *softclip =
         new Variable("softclip", VAR_SOFTCLIP, softclipStates, 5, 0);
     this->Insert(softclip);
-    Variable *clipAttenuation =
-        new Variable("clipAttenuation", VAR_CLIP_ATTENUATION, 100);
-    this->Insert(clipAttenuation);
+    Variable *softclipGain = new Variable("softclipGain", VAR_SOFTCLIP_GAIN,
+                                          softclipGainStates, 2, 0);
+    this->Insert(softclipGain);
+	Variable *masterVolume=new Variable("master", VAR_MASTERVOL, 100, 100);
+	this->Insert(masterVolume) ;
+	Variable *wrap=new Variable("wrap", VAR_WRAP, false);
+	this->Insert(wrap);
+	Variable *transpose=new Variable("transpose", VAR_TRANSPOSE, 0);
+	this->Insert(transpose);
     Variable *scale =
         new Variable("scale", VAR_SCALE, scaleNames, scaleCount, 0);
     this->Insert(scale);
@@ -96,8 +98,14 @@ int Project::GetSoftclip() {
 	return v->GetInt();
 }
 
-int Project::GetAttenuation() {
-    Variable *v = FindVariable(VAR_CLIP_ATTENUATION);
+int Project::GetSoftclipGain() {
+    Variable *v = FindVariable(VAR_SOFTCLIP_GAIN);
+    NAssert(v);
+	return v->GetBool();
+}
+
+int Project::GetPregain() {
+    Variable *v = FindVariable(VAR_PREGAIN);
     NAssert(v);
 	return v->GetInt();
 }

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -8,15 +8,15 @@
 #include "Foundation/Types/Types.h"
 #include "Foundation/Observable.h"
 
-
-#define VAR_TEMPO       MAKE_FOURCC('T','M','P','O')
-#define VAR_MASTERVOL   MAKE_FOURCC('M','S','T','R')
-#define VAR_WRAP        MAKE_FOURCC('W','R','A','P')
-#define VAR_MIDIDEVICE  MAKE_FOURCC('M','I','D','I')
-#define VAR_TRANSPOSE   MAKE_FOURCC('T','R','S','P')
-#define VAR_SOFTCLIP MAKE_FOURCC('S', 'F', 'T', 'C')
-#define VAR_CLIP_ATTENUATION MAKE_FOURCC('C', 'A', 'T', 'N')
-#define VAR_SCALE MAKE_FOURCC('S', 'C', 'A', 'L')
+#define VAR_TEMPO MAKE_FOURCC('T', 'M', 'P', 'O')
+#define VAR_MASTERVOL   	MAKE_FOURCC('M', 'S', 'T', 'R')
+#define VAR_WRAP        	MAKE_FOURCC('W', 'R', 'A', 'P')
+#define VAR_MIDIDEVICE  	MAKE_FOURCC('M', 'I', 'D', 'I')
+#define VAR_TRANSPOSE   	MAKE_FOURCC('T', 'R', 'S', 'P')
+#define VAR_SOFTCLIP 		MAKE_FOURCC('S', 'F', 'T', 'C')
+#define VAR_SOFTCLIP_GAIN 	MAKE_FOURCC('S', 'F', 'G', 'N')
+#define VAR_PREGAIN   		MAKE_FOURCC('P', 'R', 'G', 'N')
+#define VAR_SCALE 			MAKE_FOURCC('S', 'C', 'A', 'L')
 
 #define PROJECT_NUMBER "1"
 #define PROJECT_RELEASE "4"
@@ -41,7 +41,8 @@ public:
     int GetTempo() ; // Takes nudging into account
 	int GetTranspose() ;
     int GetSoftclip();
-    int GetAttenuation();
+    int GetSoftclipGain();
+    int GetPregain();
 
     void Trigger();
 

--- a/sources/Application/Model/ProjectDatas.h
+++ b/sources/Application/Model/ProjectDatas.h
@@ -1,1 +1,2 @@
-char *softclipStates[] = {"off", "subtle", "medium", "heavy", "insane"};
+char *softclipStates[] = {"Bypass", "Subtle", "Medium", "Heavy", "Insane"};
+char *softclipGainStates[] = {"(normal)", "(boosted)"};

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -109,8 +109,9 @@ void PlayerMixer::Update(Observable &o,I_ObservableData *d) {
     channel_[i]->SetMixBus(mixer->GetBus(i));
   }
   MixerService *ms=MixerService::GetInstance();
+  ms->SetPregain(project_->GetPregain());
+  ms->SetSoftclip(project_->GetSoftclip(), project_->GetSoftclipGain());
   ms->SetMasterVolume(project_->GetMasterVolume());
-  ms->SetSoftclip(project_->GetSoftclip(), project_->GetAttenuation());
   clipped_=ms->Clipped();
 } ;
 

--- a/sources/Application/Utils/minmax.cpp
+++ b/sources/Application/Utils/minmax.cpp
@@ -1,0 +1,3 @@
+// min/max macro
+
+#include "minmax.h"

--- a/sources/Application/Utils/minmax.h
+++ b/sources/Application/Utils/minmax.h
@@ -1,0 +1,2 @@
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -7,6 +7,7 @@
 #include "BaseClasses/UIActionField.h"
 #include "BaseClasses/UIField.h"
 #include "BaseClasses/UIIntVarField.h"
+#include "BaseClasses/UIStaticField.h"
 #include "BaseClasses/UITempoField.h"
 #include "Services/Midi/MidiService.h"
 #include "System/System/System.h"
@@ -102,31 +103,42 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 	GUIPoint position=GetAnchor() ;
 	
 	Variable *v=project_->FindVariable(VAR_TEMPO) ;
-	UITempoField *f=new UITempoField(ACTION_TEMPO_CHANGED,position,*v,"tempo: %d [%2.2x]  ",60,400,1,10) ;
-	T_SimpleList<UIField>::Insert(f) ;
+    UITempoField *f = new UITempoField(ACTION_TEMPO_CHANGED, position, *v,
+                                       "Tempo: %d [%2.2x]  ", 60, 400, 1, 10);
+    T_SimpleList<UIField>::Insert(f) ;
 	f->AddObserver(*this) ;
 	tempoField_=f ;
 
-	v=project_->FindVariable(VAR_MASTERVOL) ;
-	position._y+=1 ;
+    v = project_->FindVariable(VAR_PREGAIN);
+    position._y+=2 ;
     UIIntVarField *field =
-        new UIIntVarField(position, *v, "master: %d", 10, 200, 1, 10);
-    T_SimpleList<UIField>::Insert(field) ;
+        new UIIntVarField(position, *v, "Pre-gain: %d", 10, 200, 1, 10);
+    T_SimpleList<UIField>::Insert(field);
+
+    position._y += 1;
+    UIStaticField *staticField = new UIStaticField(position, "Saturation:");
+    T_SimpleList<UIField>::Insert(staticField) ;
 
     v = project_->FindVariable(VAR_SOFTCLIP);
-    position._y += 1;
-    field = new UIIntVarField(position, *v, "soft clip: %s", 0, 4, 1, 3);
+    position._x += 12; 
+    field = new UIIntVarField(position, *v, "%s", 0, 4, 1, 4);
     T_SimpleList<UIField>::Insert(field);
+    position._x -= 12;
 
-    v = project_->FindVariable(VAR_CLIP_ATTENUATION);
-    position._x += 18;
-    field = new UIIntVarField(position, *v, "post: %d", 1, 100, 1, 10);
+    v = project_->FindVariable(VAR_SOFTCLIP_GAIN);
+    position._x += 19;
+	field = new UIIntVarField(position, *v, "%s", 0, 1, 1, 1);
+	T_SimpleList<UIField>::Insert(field);
+	position._x -= 19;
+
+    v = project_->FindVariable(VAR_MASTERVOL);
+    position._y += 1;
+    field = new UIIntVarField(position, *v, "Master: %d", 0, 100, 1, 10);
     T_SimpleList<UIField>::Insert(field);
-    position._x -= 18;
 
     v = project_->FindVariable(VAR_TRANSPOSE);
-    position._y+=2 ;
-	UIIntVarField *f2=new UIIntVarField(position,*v,"transpose: %3.2d",-48,48,0x1,0xC) ;
+    position._y += 2;
+    UIIntVarField *f2=new UIIntVarField(position,*v,"Transpose: %3.2d",-48,48,0x1,0xC) ;
 	T_SimpleList<UIField>::Insert(f2) ;
 	
 	v = project_->FindVariable(VAR_SCALE);
@@ -136,7 +148,7 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
     }
     position._y += 1;
     field =
-        new UIIntVarField(position, *v, "scale: %s", 0, scaleCount - 1, 1, 10);
+        new UIIntVarField(position, *v, "Scale: %s", 0, scaleCount - 1, 1, 10);
     T_SimpleList<UIField>::Insert(field);
 
     position._y += 2;

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -14,13 +14,15 @@ Variable::Variable(const char *name,FourCC id,float value) {
 	type_=FLOAT ;
 } ;
 
-Variable::Variable(const char *name,FourCC id,int value) {
-	name_=name ;
-	id_=id ;
-	value_.int_=value ;
-    defaultValue_.int_ = value;
+Variable::Variable(const char *name, FourCC id, int value, int max) {
+    int result = max ? MIN(value, max) : value;
+	name_=name;
+	id_=id;
+	value_.int_= result;
+    defaultValue_.int_ = result;
+	maxValue_.int_ = max;
     type_=INT ;
-} ;
+};
 
 Variable::Variable(const char *name,FourCC id,bool value) {
 	name_=name ;
@@ -201,16 +203,17 @@ void Variable::SetString(const char *string,bool notify) {
 			value_.float_=float(atof(string));
 			break ;
 		case INT:
-			value_.int_=atoi(string);
-			break ;
+            value_.int_ = maxValue_.int_ ? MIN(atoi(string), maxValue_.int_)
+                                         : atoi(string);
+            break ;
 		case BOOL:
 			value_.bool_=(!strcmp("false",string)?false:true) ;
 			break ;
 		case STRING:
 			stringValue_=string ;
 			break ;
-		case CHAR_LIST:
-			value_.index_=-1 ;
+        case CHAR_LIST:
+            value_.index_=0 ;
 			for (int i=0;i<listSize_;i++) {
 				if (list_.char_[i]) {
                      const char *d=list_.char_[i] ;

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -18,34 +18,33 @@ public:
 	}  ;
 	
 public:
+  Variable(const char *name, FourCC id, int value = 0, int max = 0);
+  Variable(const char *name, FourCC id, float value = 0.0f);
+  Variable(const char *name, FourCC id, bool value = false);
+  Variable(const char *name, FourCC id, const char *value = 0);
+  Variable(const char *name, FourCC id, char **list, int size, int index = -1);
+  Variable(const char *name, FourCC id, const char *const *list, int size,
+           int index = -1);
 
-	Variable(const char *name,FourCC id,int value=0) ;
-	Variable(const char *name,FourCC id,float value=0.0f) ;
-    Variable(const char *name, FourCC id, bool value = false);
-    Variable(const char *name,FourCC id,const char *value=0) ;
-	Variable(const char *name,FourCC id,char **list,int size,int index=-1) ;
-    Variable(const char *name, FourCC id, const char *const *list, int size,
-             int index = -1);
+  virtual ~Variable();
 
-    virtual ~Variable();
+  FourCC GetID();
+  const char *GetName();
 
-    FourCC GetID();
-    const char *GetName();
-
-	Type GetType() ;
-	void SetInt(int value,bool notify=true) ;
-	int GetInt() ;
-	void SetFloat(float value,bool notify=true) ;
-	float GetFloat() ;
-	void SetString(const char *string,bool notify=true) ;
-	const char *GetString() ;
-	void SetBool(bool value,bool notify=true) ;
-	bool GetBool() ;
-	void CopyFrom(Variable &other) ;
-	// Not very clean !
-	int GetListSize() ;
-	char **GetListPointer() ;
-	void Reset() ;
+  Type GetType();
+  void SetInt(int value, bool notify = true);
+  int GetInt();
+  void SetFloat(float value, bool notify = true);
+  float GetFloat();
+  void SetString(const char *string, bool notify = true);
+  const char *GetString();
+  void SetBool(bool value, bool notify = true);
+  bool GetBool();
+  void CopyFrom(Variable &other);
+  // Not very clean !
+  int GetListSize();
+  char **GetListPointer();
+  void Reset();
 
 protected:
 	virtual void onChange() {} ;
@@ -60,22 +59,27 @@ protected:
 		bool bool_ ;
 		int index_ ;
 	} value_ ;
-	
-	union {
-		int int_ ;
+
+    union {
+        int int_ ;
 		float float_ ;
 		bool bool_ ;
 		int index_ ;
-	} defaultValue_ ;
-	
+    } maxValue_;
 
+    union {
+        int int_ ;
+		float float_ ;
+		bool bool_ ;
+		int index_ ;
+    } defaultValue_;
 
-	union {
-		char **char_ ;
-	} list_ ;
+    union {
+        char **char_ ;
+    } list_;
 
-	std::string stringValue_ ;
-	std::string stringDefaultValue_ ;
+    std::string stringValue_;
+    std::string stringDefaultValue_ ;
 
 	int listSize_ ;
 	

--- a/sources/Services/Audio/AudioMixer.cpp
+++ b/sources/Services/Audio/AudioMixer.cpp
@@ -60,18 +60,18 @@ bool AudioMixer::Render(fixed *buffer,int samplecount) {
          }
      }
 
-//  Aplply volume
+     //  Apply volume
 
-	 if (gotData) {
-		fixed *c=buffer ;
-		if (volume_!=i2fp(1)) {
-			for (int i=0;i<samplecount*2;i++) {
-				fixed v = fp_mul(*c,volume_) ;
-        *c++= v;
-			}
-		}
-	 }
-	if (enableRendering_&&writer_) {
+     if (gotData) {
+         fixed *c = buffer;
+         if (volume_ != i2fp(1)) {
+             for (int i = 0; i < samplecount * 2; i++) {
+                 fixed v = fp_mul(*c, volume_);
+                 *c++ = v;
+             }
+         }
+     }
+    if (enableRendering_&&writer_) {
 		if (!gotData) {
 			memset(buffer,0,samplecount*2*sizeof(fixed)) ;
 		} ;
@@ -81,6 +81,4 @@ bool AudioMixer::Render(fixed *buffer,int samplecount) {
      return gotData ;
 } ;
 
-void AudioMixer::SetVolume(fixed volume) {
-	volume_=volume ;
-}
+void AudioMixer::SetVolume(fixed volume) { volume_ = volume; }

--- a/sources/Services/Audio/AudioOut.h
+++ b/sources/Services/Audio/AudioOut.h
@@ -18,7 +18,8 @@ public:
    virtual bool Start()=0 ;
    virtual void Stop()=0 ;
 
-   virtual void SetSoftclip(int clip, int attn) = 0;
+   virtual void SetSoftclip(int clip, int gain) = 0;
+   virtual void SetMasterVolume(int volume) = 0;
 
    virtual void Trigger()=0 ;
 

--- a/sources/Services/Audio/AudioOutDriver.cpp
+++ b/sources/Services/Audio/AudioOutDriver.cpp
@@ -95,8 +95,8 @@ fixed AudioOutDriver::softClip(fixed sample) {
 	if (softclip_ == 0 || sample == 0) return sample;
 
 	float sampleFloat=fp2fl(sample);
-	fixed maxPositiveFloat=fp2fl(maxPositiveFixed_);
-	fixed maxNegativeFloat=fp2fl(maxNegativeFixed_);
+    float maxPositiveFloat = fp2fl(maxPositiveFixed_);
+    float maxNegativeFloat=fp2fl(maxNegativeFixed_);
 	float maxFloat;
 
 	if (sampleFloat>0) {
@@ -112,36 +112,36 @@ fixed AudioOutDriver::softClip(fixed sample) {
 	switch (softclip_) {
 		case 1:
         default:
-            alpha=1.45; // -1.5db (approx.)
-			break;
+            alpha = 1.45f; // -1.5db (approx.)
+            break;
 		case 2:
-			alpha=1.07; // -3db (approx.)
-			break;
+            alpha = 1.07f; // -3db (approx.)
+            break;
 		case 3:
-			alpha=0.75; // -6db (approx.)
-			break;
+            alpha = 0.75f; // -6db (approx.)
+            break;
 		case 4:
-			alpha=0.53; // -9db (approx.)
+            alpha = 0.53f; // -9db (approx.)
             break;
     }
 
-	float twoThirds=2.0/3.0;
-	float alphaTwoThirds=alpha*twoThirds;
-	float invertedAlpha=1.0/alpha;
+    float twoThirds = 2.0f / 3.0f;
+    float alphaTwoThirds=alpha*twoThirds;
+    float invertedAlpha = 1.0f / alpha;
 
-	x=invertedAlpha*(sampleFloat/maxFloat);
-	if (x>-1.0 && x<1.0) {
-		sampleFloat=maxFloat*(alpha*(x-(pow(x, 3)/3.0)));
-	} else {
-		sampleFloat=maxFloat*alphaTwoThirds;
-	}
+    x = invertedAlpha * (sampleFloat / maxFloat);
+    if (x > -1.0f && x < 1.0f) {
+        sampleFloat=maxFloat*(alpha*(x-(pow(x, 3.0f)/3.0f)));
+    } else {
+        sampleFloat=maxFloat*alphaTwoThirds;
+    }
 
-	float gainCompensation;
-	if (alpha > 1.0) {
-		gainCompensation=1.0/(alpha*(invertedAlpha-pow(invertedAlpha, 3)/3.0));
-	} else {
-		gainCompensation=1.0/alphaTwoThirds;
-	}
+    float gainCompensation;
+    if (alpha > 1.0f) {
+        gainCompensation=1.0f/(alpha*(invertedAlpha-pow(invertedAlpha, 3.0f)/3.0f));
+    } else {
+        gainCompensation = 1.0f / alphaTwoThirds;
+    }
     float damp = (float)attenuation_ / 100;
     return fl2fp(sampleFloat*gainCompensation*damp);
 }

--- a/sources/Services/Audio/AudioOutDriver.h
+++ b/sources/Services/Audio/AudioOutDriver.h
@@ -8,6 +8,15 @@
 class AudioDriver ;
 
 #define MIX_BUFFER_SIZE 40000
+#define MAX_POSITIVE_FIXED i2fp(32767)
+#define MAX_NEGATIVE_FIXED i2fp(-32768)
+
+struct SoftClipData {
+	float alpha;
+	float alpha23;
+	float alphaInv;
+	float gainCmp;
+};
 
 class AudioOutDriver: public AudioOut,protected I_Observer {
   public:
@@ -20,7 +29,8 @@ class AudioOutDriver: public AudioOut,protected I_Observer {
     virtual void Stop() ;
 
     virtual void Trigger() ;
-    virtual void SetSoftclip(int clip, int attenuation);
+    virtual void SetSoftclip(int clip, int gain);
+    virtual void SetMasterVolume(int volume);
 
     virtual bool Clipped() ;
 
@@ -50,9 +60,10 @@ class AudioOutDriver: public AudioOut,protected I_Observer {
     bool clipped_ ;
     bool hasSound_ ;
     int softclip_ ;
-    int attenuation_;
-    fixed maxPositiveFixed_;
-    fixed maxNegativeFixed_;
+    int softclipGain_;
+    int masterVolume_;
+
+	SoftClipData softClipData_[4];
 
     fixed *primarySoundBuffer_ ;
     short *mixBuffer_ ;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f879c44e-ceb2-4ed4-938b-be16e5f25b43)

This is a rework of softclip functionality. I've been playing with it for a while and figured how to better organize it and make it nicer and (hopefully) less confusing/annoying. 

This should go after #171

### Changes

- Changed signal flow, moved things around
- Simplified gain compensation math
- Precalculated static values for soft clipping algorithm, so they don't get recalculated for every sample anymore
- Added a max value for int variables, so old projects with incorrect values do not result in broken sound (very crude so far, not sure about it, see Variable.cpp)

Some things got a little dirty, I don't know how to make it any better at this point, so feedback is welcome! Also there's some weirdness with formatting, not sure what's going on

## Reasoning

Mainly there are three things that feel confusing/clunky:

- Master control isn't actually a master fader -- it applies gain to each of the tracks, goes before saturation stage, and can get hard clipped
- Soft clip modes all boost the volume behind the scenes, and there's no way to properly A/B when it's on and off, unless Atten is set manually, which is a pain to do and it differs for each mode;
- Atten control only works when soft clip is on, so there's no way to control volume when you drive hard clip intentionally; it is also a linear slider and doesn't feel natural as a volume slider, there's not a lot of precision when it gets quiet

These changes should address all of these issues:
- Old master is now pre-gain, and it does what it says, which is pretty much driving the clipping stage
- Soft clip gain boost is turned off by default, so there's no jump in volume, unless you want it, and it's hard to accidentally switch it on or off. Easy to a/b when it's off, and boost (maximize) volume if needed
- Atten control is now Master fader, as it should be -- works regardless of soft clip mode and feels nice to use

### Signal flow explanations

`Pre-gain (boost/cut)` → `Saturation` → `Auto-gain (boost)` → `Hard clip` → `Master (cut)`

This shouldn't affect old projects too much, only pre-gain will be reset to 100, which doesn't seem too bad.

**Pre-gain** is previous **master**, can cut or boost volume and does so across all 8 tracks; it'll be reset to 100 for old projects because of the internal name changes.

**Saturation** is the same control as before, I decided to rename it because it looked better this way :-) 

**Auto-gain** is a switch for gain compensation algorithm, which was hidden before.

By default **Auto-gain** is set to **normal**, so there's no gain added when switching between saturation modes -- this should be generally a safer volume-wise and easier to A/B between modes. Another value, **boosted**, is the current behaviour.

**Auto-gain** control goes after **Saturation** control and shifted to the right, so when scrolling down normally **Auto-gain** control never gets active. That makes it difficult to accidentally change **Auto-gain**, it has to be an intentional change, which seems good because it could result in a sudden volume jump.

**Hard clip** is always on -- it can be used as effect when **Saturation** is **Bypass/Subtle/Medium**. When using **Heavy/Insane** samples should never exceed -1/1, there should be no hard clipping even if **auto-gain** is set to **boosted**.

**Master** is a cut-only volume fader. It is meant to be used to balance tracks against each other for playing live, etc. Because of this it goes after **hard clip**, so the sound of the track doesn't change (when it was hard clipped for effect). It uses x^4 curve, which feels more natural than linear, and it can go down to 0, which allows it to be used a a simple fade-in/fade-out control. 100 is unity gain as before.

Looking forward to hear your thoughts!