### PR TITLE
Midi: Don't block Audio Thread

### DIFF
--- a/sources/System/Process/SysMutex.cpp
+++ b/sources/System/Process/SysMutex.cpp
@@ -32,6 +32,22 @@ bool SysMutex::Lock() {
 	return false ;
 }
 
+bool SysMutex::TryLock() {
+	if (!mutex_) {
+		mutex_ = SDL_CreateMutex() ;
+	}
+	if (mutex_) {
+#ifdef SDL2
+		// Returns 0 on Successs
+		return !SDL_TryLockMutex(mutex_) ;
+#else
+		SDL_LockMutex(mutex_) ;
+		return true ;
+#endif
+	} 
+	return false ;
+}
+
 void SysMutex::Unlock() {
 	if (mutex_) {
 		SDL_UnlockMutex(mutex_) ;

--- a/sources/System/Process/SysMutex.h
+++ b/sources/System/Process/SysMutex.h
@@ -21,6 +21,9 @@ public:
 	SysMutex() ;
 	~SysMutex() ;
 	bool Lock() ;
+	// Returns True if lock was succesfully taken
+	// Only on SDL2, SDL1 just calls Lock
+	bool TryLock();
 	void Unlock() ;
 private:
 	SDL_mutex *mutex_ ;


### PR DESCRIPTION
Just try and take the midi lock and if unsuccessful return and wait for the next time through. Hopefully fixes loss of audio after a period on some devices
