### PR TITLE
Add song deletion functionality 🗑️

### DIFF
--- a/sources/Application/Persistency/PersistencyService.cpp
+++ b/sources/Application/Persistency/PersistencyService.cpp
@@ -101,3 +101,22 @@ bool PersistencyService::Load() {
 	}
 	return true ;
 } ;
+
+// Delete all samples and project files, free up memory
+bool PersistencyService::Delete() {
+
+    Path filename("project:lgptsav.dat");
+    PersistencyDocument doc(filename.GetPath());
+
+    // Try opening the file
+
+    FileSystem *fs = FileSystem::GetInstance();
+    I_File *file = fs->Open(filename.GetPath().c_str(), "r");
+    if (!file)
+        return false;
+
+    // delete file ;
+    // PurgeAllInstruments()
+
+    return false;
+};

--- a/sources/Application/Persistency/PersistencyService.h
+++ b/sources/Application/Persistency/PersistencyService.h
@@ -10,6 +10,7 @@ public:
 	PersistencyService() ;
 	void Save() ;
 	bool Load() ;
+    bool Delete();
 } ;
 
 class PersistencyDocument: public TiXmlDocument {

--- a/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
@@ -9,11 +9,9 @@
 #define LIST_SIZE 20
 #define LIST_WIDTH 32
 
-static char *buttonText[3]= {
-	"Load",
-	"New",
-	"Exit"	
-} ;
+#define NUM_BUTTONS 4
+
+static char *buttonText[NUM_BUTTONS] = {"Load", "New", "Delete", "Exit"};
 
 Path SelectProjectDialog::lastFolder_("root:") ;
 int SelectProjectDialog::lastProject_ = 0 ;
@@ -103,18 +101,17 @@ void SelectProjectDialog::DrawView() {
 		count++ ;
 	} ;
 
-	y=LIST_SIZE+2 ;
-	int offset=LIST_WIDTH/4 ;
+    y = LIST_SIZE + 2;
+    int offset=LIST_WIDTH/(NUM_BUTTONS + 1);
 
 	SetColor(CD_NORMAL) ;
 
-	for (int i=0;i<3;i++) {
-		const char *text=buttonText[i] ;
+    for (int i = 0; i < NUM_BUTTONS; i++) {
+        const char *text=buttonText[i] ;
 		x=offset*(i+1)-strlen(text)/2 ;
-		props.invert_=(i==selected_)?true:false ;
-		DrawString(x,y,text,props) ;
-	}	
-
+        props.invert_ = (i == selected_) ? true : false;
+        DrawString(x, y, text, props);
+    }
 };
 
 void SelectProjectDialog::OnPlayerUpdate(PlayerEventType ,unsigned int currentTick) {
@@ -181,8 +178,18 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
 				NewProjectDialog *npd=new NewProjectDialog(*this) ;
 				DoModal(npd,NewProjectCallback) ;
 				break ;
+            }
+            case 2: // delete
+			{
+                // Is it a project directory?
+                // if so, ask form confirmation
+                // tell fs to remove it all
+                // show success (or failure)
+                // if not a project dir, show msg
+                // show SelectProectDialog once more
+                break ;
 			}
-			case 2: // Exit ;
+			case 3: // Exit ;
 				EndModal(0) ;
 				break ;
 		}
@@ -195,18 +202,18 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask,bool pressed) {
                 // No modifier
 				if (mask==EPBM_UP) warpToNextProject(-1) ;
 				if (mask==EPBM_DOWN) warpToNextProject(1) ;
-				if (mask==EPBM_LEFT) {
-					selected_-- ;
-					if (selected_<0) selected_+=3 ;
-					isDirty_=true ;
-				}
-				if (mask==EPBM_RIGHT) {
-					selected_=(selected_+1)%3 ;
-					isDirty_=true ;
-				}
-		    }
-	  } 
-	}
+                if (mask == EPBM_LEFT) {
+                    selected_--;
+					if (selected_ < 0) selected_ += NUM_BUTTONS;
+					isDirty_ = true;
+                }
+                if (mask == EPBM_RIGHT) {
+                    selected_ = (selected_ + 1) % NUM_BUTTONS;
+                    isDirty_ = true;
+                }
+            }
+      }
+    }
 };
 
 void SelectProjectDialog::warpToNextProject(int amount) {

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -94,9 +94,9 @@ static void PurgeCallback(View &v,ModalView &dialog) {
 } ;
 
 static void DeleteProjectCallback(View &v, ModalView &dialog) {
-    if (dialog.GetReturnCode()==MBL_YES) {
-		((ProjectView &)v).OnDelete() ;
-	}
+    if (dialog.GetReturnCode() == MBL_YES) {
+        ((ProjectView &)v).OnDelete();
+    }
 };
 
 ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
@@ -173,7 +173,7 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
     a1->AddObserver(*this);
     T_SimpleList<UIField>::Insert(a1);
 
-    position._y += 1;
+    position._y += 2;
     a1 = new UIActionField("Delete Song", ACTION_DELETE, position);
     a1->AddObserver(*this);
     T_SimpleList<UIField>::Insert(a1);
@@ -304,15 +304,17 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 
     case ACTION_DELETE:
       {
-        if (!player->IsRunning()) {
-          // Ideally just stop it now
-          MessageBox *mb = new MessageBox(*this, "Not while playing", MBBF_OK);
-          DoModal(mb);
+        if (player->IsRunning()) {
+            // Ideally just stop it now
+            MessageBox *mb =
+                new MessageBox(*this, "Not while playing", MBBF_OK);
+            DoModal(mb);
+        } else {
+            MessageBox *mb = new MessageBox(*this, "Delete this song forever?",
+                                            MBBF_YES | MBBF_NO);
+            DoModal(mb, DeleteProjectCallback);
         }
-        else {
-          MessageBox *mb = new MessageBox(*this, "Delete this song forever?", MBBF_YES|MBBF_NO);
-          DoModal(mb, DeleteProjectCallback);
-        }
+        break;
       }
 
 		case ACTION_QUIT:

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -18,6 +18,7 @@
 #define ACTION_QUIT             MAKE_FOURCC('Q','U','I','T')
 #define ACTION_PURGE_INSTRUMENT MAKE_FOURCC('P','R','G','I')
 #define ACTION_TEMPO_CHANGED    MAKE_FOURCC('T','E','M','P')
+#define ACTION_DELETE MAKE_FOURCC('D', 'E', 'S', 'O')
 
 static void SaveAsProjectCallback(View &v,ModalView &dialog) {
 
@@ -91,6 +92,12 @@ static void QuitCallback(View &v,ModalView &dialog) {
 static void PurgeCallback(View &v,ModalView &dialog) {
 	((ProjectView &)v).OnPurgeInstruments(dialog.GetReturnCode()==MBL_YES) ;
 } ;
+
+static void DeleteProjectCallback(View &v, ModalView &dialog) {
+    if (dialog.GetReturnCode()==MBL_YES) {
+		((ProjectView &)v).OnDelete() ;
+	}
+};
 
 ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
 
@@ -166,6 +173,11 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
     a1->AddObserver(*this);
     T_SimpleList<UIField>::Insert(a1);
 
+    position._y += 1;
+    a1 = new UIActionField("Delete Song", ACTION_DELETE, position);
+    a1->AddObserver(*this);
+    T_SimpleList<UIField>::Insert(a1);
+
     v = project_->FindVariable(VAR_MIDIDEVICE);
     NAssert(v);
     position._y += 2;
@@ -177,7 +189,6 @@ ProjectView::ProjectView(GUIWindow &w,ViewData *data):FieldView(w,data) {
     a1 = new UIActionField("Exit", ACTION_QUIT, position);
     a1->AddObserver(*this);
     T_SimpleList<UIField>::Insert(a1);
-
 }
 
 ProjectView::~ProjectView() {
@@ -249,13 +260,15 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 		case ACTION_PURGE:
 			project_->Purge() ;
 			break ;
-		case ACTION_PURGE_INSTRUMENT:
+
+        case ACTION_PURGE_INSTRUMENT:
 		{
 			MessageBox *mb=new MessageBox(*this,"Purge unused samples from disk ?",MBBF_YES|MBBF_NO) ;
 			DoModal(mb,PurgeCallback) ;
 			break ;
 		}
-		case ACTION_SAVE:
+
+        case ACTION_SAVE:
 			if (!player->IsRunning()) {
 				PersistencyService *service=PersistencyService::GetInstance() ;
 				service->Save() ;
@@ -264,14 +277,14 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 				DoModal(mb) ;
 			}
 			break ;
-		case ACTION_SAVE_AS:
+
+        case ACTION_SAVE_AS:
 			if (!player->IsRunning()) {
 				PersistencyService *service=PersistencyService::GetInstance() ;
 				service->Save() ;
 				NewProjectDialog *mb=new NewProjectDialog(*this) ;
-				DoModal(mb,SaveAsProjectCallback) ;
-
-			} else {
+                DoModal(mb, SaveAsProjectCallback);
+            } else {
 				MessageBox *mb=new MessageBox(*this,"Not while playing",MBBF_OK) ;
 				DoModal(mb) ;
 			}
@@ -288,6 +301,20 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 			}
 			break ;
 		}
+
+    case ACTION_DELETE:
+      {
+        if (!player->IsRunning()) {
+          // Ideally just stop it now
+          MessageBox *mb = new MessageBox(*this, "Not while playing", MBBF_OK);
+          DoModal(mb);
+        }
+        else {
+          MessageBox *mb = new MessageBox(*this, "Delete this song forever?", MBBF_YES|MBBF_NO);
+          DoModal(mb, DeleteProjectCallback);
+        }
+      }
+
 		case ACTION_QUIT:
 		{
 			if (!player->IsRunning()) {
@@ -299,7 +326,8 @@ void ProjectView::Update(Observable &,I_ObservableData *data) {
 			}
 			break ;
 		}
-		case ACTION_TEMPO_CHANGED:
+
+        case ACTION_TEMPO_CHANGED:
 			break ;
 		default:
 			NInvalid ;
@@ -324,6 +352,12 @@ void ProjectView::OnSaveAsProject(char * data) {
 	SetChanged();
 	NotifyObservers(&ve) ;
 } ;
+
+void ProjectView::OnDelete() {
+    SetChanged();
+    // TODO delete actually
+    // Send ViewEvent
+}
 
 void ProjectView::OnQuit() {
 	ViewEvent ve(VET_QUIT_APP) ;

--- a/sources/Application/Views/ProjectView.h
+++ b/sources/Application/Views/ProjectView.h
@@ -20,7 +20,8 @@ public:
 
 	void Update(Observable &,I_ObservableData *) ;
 
-	void OnLoadProject() ;
+    void OnDelete();
+    void OnLoadProject() ;
 	void OnSaveAsProject(char * data) ;
 	void OnPurgeInstruments(bool removeFromDisk) ;
 	void OnQuit() ;


### PR DESCRIPTION
Draft for #192 

# Description

User wants to delete projects, especially on devices with no or limited possibilities to delete files and directories "manually".

The most useful place to do so might be in the project view, because there we probably listened to and looked at the current project, whereas in the main(?) view the user would need to know the projects name in order to delete the correct one.

After deletion from the projects view, the user shall be presented the load/new ("main"?) view.

### Findings and pointers so far:

- make sure to free that projects/songs/instruments/... memory
- there is no 'delete directory' functionality implemented yet
- delete directory implementation will differ from platform to platform :(

---
---


# Description

Thank you for contributing to Little Piggy Tracker!
For fixes, please include a summary of the changes and any related issue.
For features, please include a detailed description of the new feature and how it works.

All PR:s are run through line-by-line clang-format and builds for all supported platforms.
clang-format can be applied locally on commit by installing pre-commit from repo root:
    cp pre-commit .git/hooks/

Fixes # (issue)

## Type of change

Please delete option that isn't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions on how to reproduce.

**Test Configuration**:
* Hardware:
* OS version:

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented particularly in hard-to-understand areas
- [ ] I have updated documentation regarding my changes
- [ ] My changes generate no new warnings
