### PR TITLE
Long sample names causing crashes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
         Update to github actions checkout@v4.1.7 (#136)
 
     Fixes:
+    Long sample names causing crashes in InstrumentView (#189)
     Bug in chainview: column warping (#134)
     Jumping below lowest row would cause infinite loop
     Jumping from row 0 was not possible in chainview

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -245,7 +245,13 @@ const char *Variable::GetString() {
         if ((value_.index_ < 0) || (value_.index_ >= listSize_)) {
             return "(null)";
         } else {
-            return list_.char_[value_.index_];
+            const char* src = list_.char_[value_.index_];
+            if (strlen(src) > MAX_NAME_LENGTH) {
+                strncpy(string_, src, MAX_NAME_LENGTH);
+                string_[MAX_NAME_LENGTH] = '\0';
+                return string_;
+            }
+            return src;
         }
         break;
     case STRING:

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -84,6 +84,9 @@ protected:
 	int listSize_ ;
 	
 	char string_[40] ;
+
+private:
+    static const int MAX_NAME_LENGTH = 25;
 } ;
 #endif
 


### PR DESCRIPTION
Limit character buffer to 25 in Variable for non-empty char arrays (#189)

# Description
Fixes # ([issue](https://github.com/djdiskmachine/LittleGPTracker/issues/189)

## Type of change

Please delete option that isn't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

**Test Configuration**:
* Tested in PPSSPP psp emulator
