### PR TITLE
Fix midi crash2

### DIFF
--- a/projects/Makefile.X64
+++ b/projects/Makefile.X64
@@ -11,7 +11,7 @@ DEFINES := \
         -DSDLAUDIO \
         -DRTMIDI \
         -DFFMPEG_ENABLED \
-        -D_FEAT_MIDI_MULTITHREAD
+        -D_FEAT_MIDI_LOCK
 
 ALSA_CFLAGS := $(shell pkg-config alsa --cflags)
 ALSA_LIBS := $(shell pkg-config alsa --libs)

--- a/sources/Services/Midi/MidiService.cpp
+++ b/sources/Services/Midi/MidiService.cpp
@@ -1,10 +1,9 @@
 #include "MidiService.h"
-#include "Application/Player/SyncMaster.h"
-#include "System/Console/Trace.h"
-#include "System/Timer/Timer.h"
 #include "Application/Model/Config.h"
+#include "Application/Player/SyncMaster.h"
 #include "Services/Audio/AudioDriver.h"
 #include "System/Console/Trace.h"
+#include "System/Timer/Timer.h"
 
 #ifdef SendMessage
 #undef SendMessage
@@ -14,49 +13,43 @@ MidiService::MidiService()
     : T_SimpleList<MidiOutDevice>(true), inList_(true), device_(0),
       sendSync_(true) {
 #ifndef _FEAT_MIDI_MULTITHREAD
-    for (int i=0;i<MIDI_MAX_BUFFERS;i++) {
-		queues_[i]=new T_SimpleList<MidiMessage>(true);
-	}
+    for (int i = 0; i < MIDI_MAX_BUFFERS; i++) {
+        queues_[i] = new T_SimpleList<MidiMessage>(true);
+    }
 #endif
     const char *delay = Config::GetInstance()->GetValue("MIDIDELAY");
     midiDelay_ = delay ? atoi(delay) : 1;
 
     const char *sendSync = Config::GetInstance()->GetValue("MIDISENDSYNC");
     if (sendSync) {
-		sendSync_ = (strcmp(sendSync,"YES")==0);
-	}
+        sendSync_ = (strcmp(sendSync, "YES") == 0);
+    }
 };
 
-MidiService::~MidiService() {
-	Close();
-};
+MidiService::~MidiService() { Close(); };
 
 bool MidiService::Init() {
-	Empty();
-  inList_.Empty();
-	buildDriverList();
-	// Add a merger for the input
-	merger_=new MidiInMerger();
-	IteratorPtr<MidiInDevice>it(inList_.GetIterator());
-	for (it->Begin();!it->IsDone();it->Next()) {
-		MidiInDevice &current=it->CurrentItem();
-		merger_->Insert(current);
-	}
+    Empty();
+    inList_.Empty();
+    buildDriverList();
+    // Add a merger for the input
+    merger_ = new MidiInMerger();
+    IteratorPtr<MidiInDevice> it(inList_.GetIterator());
+    for (it->Begin(); !it->IsDone(); it->Next()) {
+        MidiInDevice &current = it->CurrentItem();
+        merger_->Insert(current);
+    }
 
-	return true;
+    return true;
 };
 
-void MidiService::Close() {
-	Stop();
-};
+void MidiService::Close() { Stop(); };
 
 I_Iterator<MidiInDevice> *MidiService::GetInIterator() {
-	return inList_.GetIterator();
+    return inList_.GetIterator();
 };
 
-void MidiService::SelectDevice(const std::string &name) {
-	deviceName_ = name;
-};
+void MidiService::SelectDevice(const std::string &name) { deviceName_ = name; };
 
 bool MidiService::Start() {
 #ifndef _FEAT_MIDI_MULTITHREAD
@@ -94,8 +87,8 @@ void MidiService::Trigger() {
     AdvancePlayQueue();
 #endif
     if (device_ && sendSync_) {
-        SyncMaster *sm=SyncMaster::GetInstance();
-		if (sm->MidiSlice()) {
+        SyncMaster *sm = SyncMaster::GetInstance();
+        if (sm->MidiSlice()) {
             MidiMessage msg;
             msg.status_ = 0xF8;
             QueueMessage(msg);
@@ -111,17 +104,17 @@ void MidiService::AdvancePlayQueue() {
 }
 #endif
 
-void MidiService::Update(Observable &o,I_ObservableData *d) {
-  AudioDriver::Event *event=(AudioDriver::Event *)d;
-  if (event->type_ == AudioDriver::Event::ADET_DRIVERTICK) {
-    onAudioTick();
-  }
+void MidiService::Update(Observable &o, I_ObservableData *d) {
+    AudioDriver::Event *event = (AudioDriver::Event *)d;
+    if (event->type_ == AudioDriver::Event::ADET_DRIVERTICK) {
+        onAudioTick();
+    }
 };
 
 void MidiService::onAudioTick() {
     if (tickToFlush_ > 0) {
-        if (--tickToFlush_ ==0) {
-			flushOutQueue();
+        if (--tickToFlush_ == 0) {
+            flushOutQueue();
         }
     }
 }
@@ -129,7 +122,7 @@ void MidiService::onAudioTick() {
 void MidiService::Flush() {
     tickToFlush_ = midiDelay_;
     if (tickToFlush_ == 0) {
-		flushOutQueue();
+        flushOutQueue();
     }
 };
 
@@ -147,7 +140,7 @@ void MidiService::flushOutQueue() {
     }
     if (batch.Size() > 0) {
         device_->SendQueue(batch);
-		// Trace::Log("MidiService", "flushOutQueue: batch=0x%X", batch);
+        // Trace::Log("MidiService", "flushOutQueue: batch=0x%X", batch);
     }
 }
 #else
@@ -159,7 +152,7 @@ void MidiService::flushOutQueue() {
     }
 
     flushQueue->Empty();
-    currentOutQueue_ = next;  // Advance only after safe flush
+    currentOutQueue_ = next; // Advance only after safe flush
 }
 #endif
 
@@ -167,62 +160,64 @@ void MidiService::flushOutQueue() {
  * starts midi device
  */
 void MidiService::startDevice() {
-	IteratorPtr<MidiOutDevice>it(GetIterator()) ;
+    IteratorPtr<MidiOutDevice> it(GetIterator());
 
-	for (it->Begin(); !it->IsDone(); it->Next()) {
-		MidiOutDevice &current = it->CurrentItem();
-		if (!strcmp(deviceName_.c_str(), current.GetName())) {
-			if (current.Init()) {
-				if (current.Start()) {
-					Trace::Log("MidiService", "midi device %s started", deviceName_.c_str());
-					device_ = &current;
-				} else {
-					Trace::Log("MidiService", "midi device %s failed to start", deviceName_.c_str());
-					current.Close();
-				}
-			}
-			break;
-		}
-	}
+    for (it->Begin(); !it->IsDone(); it->Next()) {
+        MidiOutDevice &current = it->CurrentItem();
+        if (!strcmp(deviceName_.c_str(), current.GetName())) {
+            if (current.Init()) {
+                if (current.Start()) {
+                    Trace::Log("MidiService", "midi device %s started",
+                               deviceName_.c_str());
+                    device_ = &current;
+                } else {
+                    Trace::Log("MidiService", "midi device %s failed to start",
+                               deviceName_.c_str());
+                    current.Close();
+                }
+            }
+            break;
+        }
+    }
 };
 
 /*
  * closes midi device
  */
 void MidiService::stopDevice() {
-	if (device_) {
-		device_->Stop() ;
-		device_->Close() ;
-	}
-	device_=0 ;
-} ;
+    if (device_) {
+        device_->Stop();
+        device_->Close();
+    }
+    device_ = 0;
+};
 
 /*
  * starts midi device when playback starts
  */
 void MidiService::OnPlayerStart() {
-	if (deviceName_.size()!=0) {
-		stopDevice();
-		startDevice();
-		deviceName_="";
-	} else {
-    startDevice();
-  }
+    if (deviceName_.size() != 0) {
+        stopDevice();
+        startDevice();
+        deviceName_ = "";
+    } else {
+        startDevice();
+    }
 
-	if (sendSync_) {
-		MidiMessage msg ;
-		msg.status_=0xFA ;
-		QueueMessage(msg) ;
-	}
+    if (sendSync_) {
+        MidiMessage msg;
+        msg.status_ = 0xFA;
+        QueueMessage(msg);
+    }
 };
 
 /*
  * queues midi stop message when player stops
  */
 void MidiService::OnPlayerStop() {
-	if (sendSync_) {
-		MidiMessage msg ;
-		msg.status_=0xFC ;
-		QueueMessage(msg) ;
-	}
+    if (sendSync_) {
+        MidiMessage msg;
+        msg.status_ = 0xFC;
+        QueueMessage(msg);
+    }
 };

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -7,6 +7,7 @@
 #include "MidiInDevice.h"
 #include "MidiInMerger.h"
 #include "MidiOutDevice.h"
+#include "System/Process/SysMutex.h"
 #include "System/Timer/Timer.h"
 #include <string>
 #ifdef _FEAT_MIDI_MULTITHREAD
@@ -82,6 +83,9 @@ class MidiService : public T_Factory<MidiService>,
     T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS];
     int currentPlayQueue_;
     int currentOutQueue_;
+#ifdef _FEAT_MIDI_LOCK
+    SysMutex queueMutex_;
+#endif
 #endif
 
     MidiInMerger *merger_;

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -15,79 +15,78 @@
 
 #define MIDI_MAX_BUFFERS 20
 
-class MidiService
-:public T_Factory<MidiService>
-,public T_SimpleList<MidiOutDevice>
-,public I_Observer
-{
+class MidiService : public T_Factory<MidiService>,
+                    public T_SimpleList<MidiOutDevice>,
+                    public I_Observer {
 
-public:
-	MidiService() ;
-	virtual ~MidiService() ;
+  public:
+    MidiService();
+    virtual ~MidiService();
 
-	bool Init() ;
-	void Close() ;
-	bool Start() ;
-	void Stop() ;
+    bool Init();
+    void Close();
+    bool Start();
+    void Stop();
 
-	void SelectDevice(const std::string &name) ;
+    void SelectDevice(const std::string &name);
 
-	I_Iterator<MidiInDevice> *GetInIterator() ;
+    I_Iterator<MidiInDevice> *GetInIterator();
 
-	//! player notification
+    //! player notification
 
-	void OnPlayerStart() ;
-	void OnPlayerStop() ;
+    void OnPlayerStart();
+    void OnPlayerStop();
 
-	//! Queues a MidiMessage to the current time chunk
+    //! Queues a MidiMessage to the current time chunk
 
-	void QueueMessage(MidiMessage &) ;
+    void QueueMessage(MidiMessage &);
 
-	//! Time chunk trigger
+    //! Time chunk trigger
 
     void Trigger();
 #ifndef _FEAT_MIDI_MULTITHREAD
     void AdvancePlayQueue();
 #endif
-	//! Flush current queue to the output
+    //! Flush current queue to the output
 
     void Flush();
 
   protected:
-    T_SimpleList<MidiInDevice> inList_ ;
+    T_SimpleList<MidiInDevice> inList_;
 
     virtual void Update(Observable &o, I_ObservableData *d);
     void onAudioTick();
 
-	//! start the selected midi device
+    //! start the selected midi device
 
-	void startDevice() ;
+    void startDevice();
 
-	//! stop the selected midi device
+    //! stop the selected midi device
 
-	void stopDevice() ;
+    void stopDevice();
 
-	//! build the list of available drivers
+    //! build the list of available drivers
 
-	virtual void buildDriverList()=0 ;
+    virtual void buildDriverList() = 0;
 
-private:
-  void flushOutQueue();
-private:
-  std::string deviceName_;
-  MidiOutDevice *device_;
+  private:
+    void flushOutQueue();
+
+  private:
+    std::string deviceName_;
+    MidiOutDevice *device_;
 
 #ifdef _FEAT_MIDI_MULTITHREAD
-  moodycamel::ConcurrentQueue<MidiMessage> midiQueue_;
+    moodycamel::ConcurrentQueue<MidiMessage> midiQueue_;
 #else
-  T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS];
-  int currentPlayQueue_;
-  int currentOutQueue_;
+    T_SimpleList<MidiMessage> *queues_[MIDI_MAX_BUFFERS];
+    int currentPlayQueue_;
+    int currentOutQueue_;
 #endif
 
-  MidiInMerger *merger_;
-  int midiDelay_;
-  int tickToFlush_;
-  bool sendSync_;
+    MidiInMerger *merger_;
+    int midiDelay_;
+    int tickToFlush_;
+    bool sendSync_;
 };
 #endif


### PR DESCRIPTION
# Description

Use Mutex Locker for midi on X64
    
This commit protects the midi queue with a basic mutex locker on
X64. So far it seems like this keeps midi working, doesn't crash
or end up with audio hanging.

This is split into 2 commits, the first is just clang format, the best way to view the functional changes is by reviewing the commits individually particularly the second.

## Type of change
- Fixes #225

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested this for a couple of days on my rg35xx with some additional changes for midi in, (my rg35xx is using a build that is identical to X64)

**Test Configuration**:
* Hardware: rg35xx-plus
* Test steps:
  - Ran with audio + midi for several hours, tried starting and stopping multiple times in between

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented particularly in hard-to-understand areas
- [ ] I have updated CHANGELOG
- [ ] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [ ] I have version bumped in `sources/Application/Model/Project.h`
- [X] My changes generate no new warnings (build without your change then apply your change to check this)
