### PR TITLE
chore: expose CONSOLE colour and update docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
+1.6.0-bacon19
+    Expose CONSOLE colour in config and update docs
 
+1.6.0-bacon18
     Migrate W32 to SDL2, removing need for building in vs2008
 
 1.6.0-bacon17

--- a/docs/LittlePiggyTrackerConf.md
+++ b/docs/LittlePiggyTrackerConf.md
@@ -117,7 +117,7 @@ LittleGPTracker uses 6 colours to do all the drawing. If you want, you can redef
 - `FOREGROUND`: Color of the foreground
 - `BORDER`: Color of the border in the start screen / dialogs
 - `HICOLOR1`: Row count in song screen
-- `HICOLOR2`: Highlight color 2
+- `HICOLOR2`: Highlight color 2 as well as warning level ('orange') in VU meter
 - `CURSORCOLOR`: Cursor color
 - `PLAYCOLOR`: Play indicator color
 - `MUTECOLOR`: Mute indicator color
@@ -125,7 +125,8 @@ LittleGPTracker uses 6 colours to do all the drawing. If you want, you can redef
 - `SONGVIEW_00`: Color of the chain "00" in song screen
 - `ROWCOLOR1`: Row count color 1
 - `ROWCOLOR2`: Row count color 2
-- `MAJORBEAT`: Color of "--" at row 00,04,08,0c in phrase screen
+- `MAJORBEAT`: Color of rows 00,04,08,0c in phrase screen as well as clipping indicator ('red') in VU meter
+- `CONSOLE`: Color of normal signal level ('green') in VU meter
 - `ALTROWNUMBER`: How many rows for each `ROWCOLOR`
 
 All colors are defined by a set of hexadecimal triplet for RGB. Here's an example:

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -114,6 +114,7 @@ AppWindow::AppWindow(I_GUIWindowImp &imp) : GUIWindow(imp) {
     defineColor("ROWCOLOR1", rownumberColor_);
     defineColor("ROWCOLOR2", rownumber2Color_);
     defineColor("MAJORBEAT", majorbeatColor_);
+    defineColor("CONSOLE", consoleColor_);
 
     GUIWindow::Clear(backgroundColor_);
 

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -21,7 +21,7 @@
 
 #define PROJECT_NUMBER "1"
 #define PROJECT_RELEASE "6"
-#define BUILD_COUNT "0-bacon17"
+#define BUILD_COUNT "0-bacon19"
 
 #define MAX_TAP 3
 


### PR DESCRIPTION
# Description
This PR exposes the `CONSOLE` colour for the purpose of customising the VU meter colour. Docs have been updated to reflect this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Set `CONSOLE` colour in config.xml as outlined in the docs.

**Test Configuration**:
* Hardware: x64, aarch64
* Test steps:
See above.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented particularly in hard-to-understand areas
- [x] I have updated CHANGELOG
- [x] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [x] I have version bumped in `sources/Application/Model/Project.h`
- [x] My changes generate no new warnings (build without your change then apply your change to check this)
