### PR TITLE
New map presentation

### DIFF
--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -81,23 +81,26 @@ void View::drawMap() {
     	GUITextProperties props ;
 
 		//draw entire map
-		SetColor(CD_HILITE1) ;
-    	char buffer[5] ;
-		props.invert_=true ;
-		//row1
+        SetColor(CD_ROW2);
+        props.invert_ = false ;
+        char buffer[5] ;
+        //row1
 		sprintf(buffer,"P G ");
         DrawString(pos._x,pos._y,buffer,props) ;
 		pos._y++ ;		
 		//row2
-		sprintf(buffer,"SCPI");
+        SetColor(CD_ROW);
+        sprintf(buffer,"SCPI");
         DrawString(pos._x,pos._y,buffer,props) ;
 		pos._y++ ;		
 		//row3
+        SetColor(CD_ROW2);
         sprintf(buffer, " MTT");
         DrawString(pos._x,pos._y,buffer,props) ;
 
 		//draw current screen on map
-		SetColor(CD_HILITE2) ;
+        SetColor(CD_CURSOR);
+        props.invert_ = true ;
 		pos._y = anchor._y;
 		switch(viewType_)
 		{


### PR DESCRIPTION
# Description
Changes how the map is presented.
Instead of using the "inverted" presentation, it will only present the letters, making it less "blocking".
This will also change the colors used to create the map, making it closer to the row indicators.
The selected cursor also changed.

<img width="1700" height="1374" alt="Screenshot From 2026-08-16 21-26-41" src="https://github.com/user-attachments/assets/3b47541a-74ec-4bd6-96ef-0cf546000011" />

Depends on pr #270.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**: Linux X64
* Hardware: Intel PC
* Test steps:
  1. open a project
  2. navigate through all the pages

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented particularly in hard-to-understand areas
- [ ] I have updated CHANGELOG
- [ ] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [ ] I have version bumped in `sources/Application/Model/Project.h`
- [ ] My changes generate no new warnings (build without your change then apply your change to check this)

# Notice
This is kinda of a draft, I will love to hear feedback on how should be be configured:
1. create a new color configuration for each option, including the invert
2. create a new configuration to enable this
3. something else?

Because of that I have not completed the checklist or updated the CHANGELOG.