### PR TITLE
feat: add HOP --FF variant

### DIFF
--- a/docs/wiki/What-is-LittlePiggyTracker.md
+++ b/docs/wiki/What-is-LittlePiggyTracker.md
@@ -507,7 +507,7 @@ ARPG 4050: loops between original pitch, +4 semitones, +0 semitones, + 5 semiton
 
 ## HOP aabb
 
-**play position will jump to the next phrase in a chain, jumping directly at position bb in the phrase.**
+**play position will jump to the next phrase in a chain, jumping directly at position bb in the phrase, unless bb = FF, in which case the channel will be stopped**
 
 - hop is instant: instrument triggers and commands on the same row will be run.
 - no effect on instruments

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -672,6 +672,27 @@ bool Player::ProcessChannelCommand(int channel, FourCC cmd, ushort param) {
             gr->SetGroove(channel, param);
         }
     } break;
+    case I_CMD_HOP: {
+      bool channel_stop = param & 0xFF == 0xFF;
+      if (channel_stop) {
+	// Stop current channel
+	mixer_->StopChannel(channel);
+
+	// If all channels are stopped, stop the song if in song mode.
+	if(GetSequencerMode() == SM_SONG) {
+	bool all_channels_stopped = true;
+	for (int c = 0; c < SONG_CHANNEL_COUNT; c++) {
+	  all_channels_stopped &=
+	    !mixer_->IsChannelPlaying(c);
+	}
+	if (all_channels_stopped) {
+	  Stop();
+	}
+	} else {
+	  liveQueueingMode_[channel] = QM_NONE;
+	}
+      }
+    } break;
         case I_CMD_STOP: {
             switch (GetSequencerMode()) {
             case SM_SONG:
@@ -882,14 +903,24 @@ void Player::playCursorPosition(int channel) {
 int Player::getChannelHop(int channel, int pos) {
 
     int phrase = viewData_->currentPlayPhrase_[channel];
-    FourCC cc = viewData_->song_->phrase_->cmd1_[phrase * 16 + pos];
-    if (cc == I_CMD_HOP) {
-        return (viewData_->song_->phrase_->param1_[phrase * 16 + pos]) & 0xF;
-    }
-    cc = viewData_->song_->phrase_->cmd2_[phrase * 16 + pos];
-    if (cc == I_CMD_HOP) {
-        return (viewData_->song_->phrase_->param2_[phrase * 16 + pos]) & 0xF;
-    }
+
+    Phrase *song_phrase = viewData_->song_->phrase_;
+    FourCC cc[] = {song_phrase->cmd1_[phrase * 16 + pos],
+		 song_phrase->cmd2_[phrase * 16 + pos]};
+    int param[] = {song_phrase->param1_[phrase * 16 + pos],
+		   song_phrase->param2_[phrase * 16 + pos]};
+
+    // First hop takes precedence.
+    for(int i = 0; i < 2; i++)
+      if (cc[i] == I_CMD_HOP) {
+	int arg = param[i] & 0xFF;
+	if (arg != 0xFF)
+	  return arg & 0xF;
+	else
+	  // 'Hop stop' deferred to command processing stage.
+	  return -1;
+      }
+    
   return -1;
 }
 

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -673,24 +673,23 @@ bool Player::ProcessChannelCommand(int channel, FourCC cmd, ushort param) {
         }
     } break;
     case I_CMD_HOP: {
-      bool channel_stop = param & 0xFF == 0xFF;
-      if (channel_stop) {
-	// Stop current channel
-	mixer_->StopChannel(channel);
+        bool channel_stop = (param & 0xFF) == 0xFF;
+        if (channel_stop) {
+            // Stop current channel
+            mixer_->StopChannel(channel);
 
-	// If all channels are stopped, stop the song if in song mode.
-	if(GetSequencerMode() == SM_SONG) {
-	bool all_channels_stopped = true;
-	for (int c = 0; c < SONG_CHANNEL_COUNT; c++) {
-	  all_channels_stopped &=
-	    !mixer_->IsChannelPlaying(c);
-	}
-	if (all_channels_stopped) {
-	  Stop();
-	}
-	} else {
-	  liveQueueingMode_[channel] = QM_NONE;
-	}
+            // If all channels are stopped, stop the song if in song mode.
+            if (GetSequencerMode() == SM_SONG) {
+                bool all_channels_stopped = true;
+                for (int c = 0; c < SONG_CHANNEL_COUNT; c++) {
+                    all_channels_stopped &= !mixer_->IsChannelPlaying(c);
+                }
+                if (all_channels_stopped) {
+                    Stop();
+                }
+            } else {
+                liveQueueingMode_[channel] = QM_NONE;
+            }
       }
     } break;
         case I_CMD_STOP: {


### PR DESCRIPTION
# Description

This PR adds a channel-stopping feature in the form of `HOP --FF`, cf. LSDJ's `HFF` (which is `STOP` in LGPT). While the same functionality may be accomplished using `STOP` in live mode, this change allows channel-stopping in song mode, which comes in handy when for instance a song is fully sequenced and a count-in or head is to be played only once at the start.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Use the `HOP` command with argument `aaFF` and note that it behaves similarly to `STOP` except only the current channel stops playing.

**Test Configuration**:
* Hardware: x64, aarch64 Linux
* Test steps:
See above.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented particularly in hard-to-understand areas
- [ ] I have updated CHANGELOG
- [x] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [ ] I have version bumped in `sources/Application/Model/Project.h`
- [x] My changes generate no new warnings (build without your change then apply your change to check this)
- [x]  No LLMs or other sources or tools that may call this project's integrity or license into question have been used or consulted